### PR TITLE
Release v0.3.1：LPMM 导入与删除机制修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # 更新日志 (Changelog)
 
+## [0.3.1] - 2026-02-07
+
+本次更新为 **稳定性补丁版本**，主要修复脚本导入链路、删除安全性与 LPMM 转换一致性问题。
+
+### 🛠️ 关键修复
+
+#### 新增功能
+
+- 新增 `scripts/convert_lpmm.py`：
+  - 支持将 LPMM 的 `parquet + graph` 数据直接转换为 A_Memorix 存储结构；
+  - 提供 LPMM ID 到 A_Memorix ID 的映射能力，用于图节点/边重写；
+  - 当前实现优先保证检索一致性，关系向量采用安全策略（不直接导入）。
+
+#### 导入链路
+
+- 修复 `import_lpmm_json.py` 依赖的 `AutoImporter.import_json_data` 公共入口缺失/不稳定问题，确保外部脚本可稳定调用 JSON 直导入流程。
+
+#### 删除安全
+
+- 修复按来源删除时“同一 `(subject, object)` 存在多关系”场景下的误删风险：
+  - `MetadataStore.delete_paragraph_atomic` 新增 `relation_prune_ops`；
+  - 仅在无兄弟关系时才回退删除整条边。
+- `delete_knowledge.py` 新增保守孤儿实体清理（仅对本次候选实体执行，且需同时满足无段落引用、无关系引用、图无邻居）。
+- `delete_knowledge.py` 改为读取向量元数据中的真实维度，避免 `dimension=1` 写回污染。
+
+#### LPMM 转换修复
+
+- 修复 `convert_lpmm.py` 中向量 ID 与 `MetadataStore` 哈希不一致导致的检索反查失败问题。
+- 为避免脏召回，转换阶段暂时跳过 `relation.parquet` 的直接向量导入（待关系元数据一一映射能力完善后再恢复）。
+
+### 🔖 版本信息
+
+- 插件版本：`0.3.0` → `0.3.1`
+
 ## [0.3.0] - 2026-01-30
 
 本次更新引入了 **V5 动态记忆系统**，实现了符合生物学特性的记忆衰减、强化与全声明周期管理，并提供了配套的指令与工具。

--- a/IMPORT_GUIDE.md
+++ b/IMPORT_GUIDE.md
@@ -113,6 +113,34 @@ python plugins/A_memorix/scripts/import_lpmm_json.py <包含json的目录或文�
 
 ---
 
+---
+
+## 4. LPMM 二进制直转 (无需 Token)
+
+如果您希望**完全保留** LPMM 的原始 Embedding 向量和图结构，且**不消耗任何 Token**，可以使用直接转换脚本。
+
+> **⚠️ 注意**：这要求 A_memorix 配置的 Embedding 维度与原 LPMM 项目完全一致。
+
+**命令：**
+
+```bash
+python plugins/A_memorix/scripts/convert_lpmm.py --input <LPMM数据目录> --output <A_memorix数据目录>
+```
+
+**示例：**
+
+Assume LPMM data is in `data/lpmm_storage` and you want to output to `plugins/A_memorix/data`.
+
+```bash
+python plugins/A_memorix/scripts/convert_lpmm.py -i data/lpmm_storage -o plugins/A_memorix/data
+```
+
+此脚本会：
+
+1. 直接读取 `.parquet` 文件并转换为 A_memorix 的二进制向量格式。
+2. 直接读取 `.graphml` 或 `.pkl` 文件并转换为稀疏矩阵图。
+3. 自动重建元数据。
+
 ## 常用命令速查
 
 ### 自动导入 (推荐)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # A_Memorix
 
-**轻量级知识图谱插件** - 基于双路检索的完全独立的记忆增强系统 (v0.3.0)
+**轻量级知识图谱插件** - 基于双路检索的完全独立的记忆增强系统 (v0.3.1)
 
 > 消えていかない感覚 , まだまだ足りてないみたい !
 
 > [!WARNING]
 > **重要提示**：v0.2.0 版本由于底层存储架构重构（引入 SciPy 稀疏矩阵与 Faiss SQ8 量化），**与 v0.1.3 及早期版本的导入数据不完全兼容**。
 > 升级后，虽然系统会尝试自动迁移部分数据，但为确保知识图谱的检索精度和完整性，强烈建议在升级后使用 `process_knowledge.py` 脚本重新导入原始文本。
+
+> [!NOTE]
+> **v0.3.1 补丁更新**：
+> 1. 修复 `import_lpmm_json.py -> process_knowledge.py` 公共导入接口链路；
+> 2. 修复按来源删除时的关系边误删风险，并增加保守的孤儿实体清理；
+> 3. 修复 `convert_lpmm.py` 的向量 ID 与元数据 hash 一致性问题。
 
 ---
 
@@ -93,6 +99,19 @@ python plugins/A_memorix/scripts/import_lpmm_json.py <path_to_json_file_or_dir>
 
 - `path`: JSON 文件路径或包含 `*-openie.json` 的目录。
 - `--force`: 强制重新导入。
+
+### 1.2 转换 LPMM 存储文件 (`convert_lpmm.py`)  [新增]
+
+如果你有 LPMM 导出的 parquet/graph 文件，可使用该脚本直接转换为 A_Memorix 存储结构：
+
+```bash
+python plugins/A_memorix/scripts/convert_lpmm.py -i <lpmm_data_dir> -o <output_data_dir> --dim 384
+```
+
+**说明：**
+
+- 输入目录支持 `paragraph.parquet`、`entity.parquet` 以及 `rag-graph.graphml/graph.graphml/graph_structure.pkl`。
+- 当前版本优先保证 ID 与元数据一致性，关系向量不做直接导入（避免检索反查不一致）。
 
 ### 2. 指令交互
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,8 +4,8 @@ A_Memorix - 轻量级知识库插件
 完全独立的记忆增强系统，优化低资源环境下的知识存储与检索。
 """
 
-__version__ = "0.1.0"
-__author__ = "MaiBot Team"
+__version__ = "0.3.1"
+__author__ = "A_Dawn"
 
 from .plugin import A_MemorixPlugin
 

--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "A_Memorix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "轻量级知识库插件 - 基于双路检索的完全独立的记忆增强系统，优化低资源环境下的知识存储与检索",
   "author": {
     "name": "A_Dawn"

--- a/plugin.py
+++ b/plugin.py
@@ -64,7 +64,7 @@ class A_MemorixPlugin(BasePlugin):
 
     # 插件基本信息（PluginBase要求的抽象属性）
     plugin_name = "A_Memorix"
-    plugin_version = "0.3.0"
+    plugin_version = "0.3.1"
     plugin_description = "轻量级知识库插件 - 完全独立的记忆增强系统"
     plugin_author = "A_Dawn"
     enable_plugin = False  # 默认禁用，需要在config.toml中启用

--- a/scripts/convert_lpmm.py
+++ b/scripts/convert_lpmm.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+LPMM 到 A_memorix 存储转换器
+
+功能：
+1. 读取 LPMM parquet 文件 (paragraph.parquet, entity.parquet, relation.parquet)
+2. 读取 LPMM 图文件 (graph.graphml 或 graph_structure.pkl)
+3. 直接写入 A_memorix 二进制 VectorStore 和稀疏 GraphStore
+4. 绕过 Embedding 生成以节省 Token
+"""
+
+import sys
+import os
+import json
+import argparse
+import asyncio
+import pickle
+import logging
+from pathlib import Path
+from typing import Dict, Any, List, Tuple
+import numpy as np
+
+# 设置路径
+current_dir = Path(__file__).resolve().parent
+plugin_root = current_dir.parent
+project_root = plugin_root.parent.parent
+sys.path.insert(0, str(project_root))
+
+# 设置日志
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("LPMM_Converter")
+
+try:
+    import networkx as nx
+    from scipy import sparse
+    import pyarrow.parquet as pq
+except ImportError as e:
+    logger.error(f"缺少依赖: {e}")
+    logger.error("请安装: pip install pandas pyarrow networkx scipy")
+    sys.exit(1)
+
+try:
+    # 优先采取相对导入 (将插件根目录加入路径)
+    # 这样可以避免硬编码插件名称 (plugins.A_memorix)
+    if str(plugin_root) not in sys.path:
+        sys.path.insert(0, str(plugin_root))
+    
+    from core.storage.vector_store import VectorStore
+    from core.storage.graph_store import GraphStore
+    from core.storage.metadata_store import MetadataStore
+    from core.storage import QuantizationType, SparseMatrixFormat
+    
+except ImportError as e:
+    logger.error(f"无法导入 A_memorix 核心模块: {e}")
+    logger.error("请确保在正确的环境中运行，且已安装所有依赖。")
+    sys.exit(1)
+
+
+class LPMMConverter:
+    def __init__(
+        self,
+        lpmm_data_dir: Path,
+        output_dir: Path,
+        dimension: int = 384,
+        batch_size: int = 1024,
+    ):
+        self.lpmm_dir = lpmm_data_dir
+        self.output_dir = output_dir
+        self.dimension = dimension
+        self.batch_size = max(1, int(batch_size))
+        
+        self.vector_dir = output_dir / "vectors"
+        self.graph_dir = output_dir / "graph"
+        self.metadata_dir = output_dir / "metadata"
+        
+        self.vector_store = None
+        self.graph_store = None
+        self.metadata_store = None
+        # LPMM 原 ID -> A_memorix ID 映射（用于图重写）
+        self.id_mapping: Dict[str, str] = {}
+
+    def _register_id_mapping(self, raw_id: Any, mapped_id: str, p_type: str) -> None:
+        """记录 ID 映射，兼容带/不带类型前缀两种格式。"""
+        if raw_id is None:
+            return
+
+        raw = str(raw_id).strip()
+        if not raw:
+            return
+
+        self.id_mapping[raw] = mapped_id
+
+        prefix = f"{p_type}-"
+        if raw.startswith(prefix):
+            self.id_mapping[raw[len(prefix):]] = mapped_id
+        else:
+            self.id_mapping[prefix + raw] = mapped_id
+
+    def _map_node_id(self, node: Any) -> str:
+        """将图节点 ID 映射到转换后的 A_memorix ID。"""
+        node_key = str(node)
+        return self.id_mapping.get(node_key, node_key)
+        
+    def initialize_stores(self):
+        """初始化空的 A_memorix 存储"""
+        logger.info(f"正在初始化存储于 {self.output_dir}...")
+        
+        # 初始化 VectorStore (A_memorix 默认使用 INT8 量化)
+        self.vector_store = VectorStore(
+            dimension=self.dimension,
+            quantization_type=QuantizationType.INT8,
+            data_dir=self.vector_dir
+        )
+        self.vector_store.clear() # 清空旧数据
+        
+        # 初始化 GraphStore (使用 CSR 格式)
+        self.graph_store = GraphStore(
+            matrix_format=SparseMatrixFormat.CSR,
+            data_dir=self.graph_dir
+        )
+        self.graph_store.clear()
+        
+        # 初始化 MetadataStore
+        self.metadata_store = MetadataStore(data_dir=self.metadata_dir)
+        self.metadata_store.connect()
+        # 清空元数据表？理想情况下是的，但要小心。
+        # 对于转换，我们假设是全新的开始或覆盖。
+        # A_memorix 中的 MetadataStore 通常使用 SQLite。
+        # 如果目录是新的，我们会依赖它创建新文件。
+        
+    def convert_vectors(self):
+        """将 Parquet 向量转换为 VectorStore"""
+        # LPMM 默认文件名
+        parquet_files = {
+            "paragraph": self.lpmm_dir / "paragraph.parquet",
+            "entity": self.lpmm_dir / "entity.parquet",
+            "relation": self.lpmm_dir / "relation.parquet"
+        }
+        
+        total_vectors = 0
+        
+        for p_type, p_path in parquet_files.items():
+            # 关系向量在当前脚本中无法保证与 MetadataStore 的关系记录一一对应，
+            # 直接导入会污染召回结果（命中后无法反查 relation 元数据）。
+            if p_type == "relation":
+                logger.warning("跳过 relation.parquet 导入：当前版本仅导入 paragraph/entity 向量以保证一致性。")
+                continue
+
+            if not p_path.exists():
+                logger.warning(f"文件未找到: {p_path}, 跳过 {p_type} 向量。")
+                continue
+                
+            logger.info(f"正在处理 {p_type} 向量，来源: {p_path}...")
+            try:
+                parquet_file = pq.ParquetFile(p_path)
+                total_rows = parquet_file.metadata.num_rows
+                if total_rows == 0:
+                    logger.info(f"{p_path} 为空，跳过。")
+                    continue
+
+                # LPMM Schema: 'hash', 'embedding', 'str'
+                cols = parquet_file.schema_arrow.names
+                # 兼容性检查
+                content_col = 'str' if 'str' in cols else 'content'
+                emb_col = 'embedding'
+                hash_col = 'hash'
+                
+                if content_col not in cols or emb_col not in cols:
+                    logger.error(f"{p_path} 中缺少必要列 (需包含 {content_col}, {emb_col})。发现: {cols}")
+                    continue
+                
+                batch_columns = [content_col, emb_col]
+                if hash_col in cols:
+                    batch_columns.append(hash_col)
+
+                processed_rows = 0
+                added_for_type = 0
+                batch_idx = 0
+
+                for record_batch in parquet_file.iter_batches(
+                    batch_size=self.batch_size,
+                    columns=batch_columns,
+                ):
+                    batch_idx += 1
+                    df_batch = record_batch.to_pandas()
+
+                    embeddings_list = []
+                    ids_list = []
+
+                    # 同时处理元数据映射
+                    for _, row in df_batch.iterrows():
+                        processed_rows += 1
+                        content = row[content_col]
+                        emb = row[emb_col]
+
+                        if content is None or (isinstance(content, float) and np.isnan(content)):
+                            continue
+                        content = str(content).strip()
+                        if not content:
+                            continue
+
+                        if emb is None or len(emb) == 0:
+                            continue
+
+                        # 先写 MetadataStore，并使用其返回的真实 hash 作为向量 ID
+                        # 保证检索返回 ID 可以直接反查元数据。
+                        store_id = None
+                        if p_type == "paragraph":
+                            store_id = self.metadata_store.add_paragraph(
+                                content=content,
+                                source="lpmm_import",
+                                knowledge_type="imported",
+                            )
+                        elif p_type == "entity":
+                            store_id = self.metadata_store.add_entity(name=content)
+                        else:
+                            continue
+
+                        raw_hash = row[hash_col] if hash_col in df_batch.columns else None
+                        if raw_hash is not None and not (isinstance(raw_hash, float) and np.isnan(raw_hash)):
+                            self._register_id_mapping(raw_hash, store_id, p_type)
+                        
+                        # 确保 embedding 是 numpy 数组
+                        emb_np = np.array(emb, dtype=np.float32)
+                        if emb_np.shape[0] != self.dimension:
+                            logger.error(f"维度不匹配: {emb_np.shape[0]} vs {self.dimension}")
+                            continue
+                            
+                        embeddings_list.append(emb_np)
+                        ids_list.append(store_id)
+                    
+                    if embeddings_list:
+                        # 分批添加到向量存储
+                        vectors_np = np.stack(embeddings_list)
+                        count = self.vector_store.add(vectors_np, ids_list)
+                        added_for_type += count
+                        total_vectors += count
+
+                    if batch_idx == 1 or batch_idx % 10 == 0:
+                        logger.info(
+                            f"[{p_type}] 批次 {batch_idx}: 已扫描 {processed_rows}/{total_rows}, 已导入 {added_for_type}"
+                        )
+
+                logger.info(
+                    f"{p_type} 向量处理完成：总扫描 {processed_rows}，总导入 {added_for_type}"
+                )
+                    
+            except Exception as e:
+                logger.error(f"处理 {p_path} 时出错: {e}")
+                
+        # 提交向量存储
+        self.vector_store.save()
+        logger.info(f"向量转换完成。总向量数: {total_vectors}")
+
+    def convert_graph(self):
+        """将 LPMM 图转换为 GraphStore"""
+        # LPMM 默认文件名是 rag-graph.graphml
+        graph_files = [
+            self.lpmm_dir / "rag-graph.graphml",
+            self.lpmm_dir / "graph.graphml",
+            self.lpmm_dir / "graph_structure.pkl"
+        ]
+        
+        nx_graph = None
+        
+        for g_path in graph_files:
+            if g_path.exists():
+                logger.info(f"发现图文件: {g_path}")
+                try:
+                    if g_path.suffix == ".graphml":
+                        nx_graph = nx.read_graphml(g_path)
+                    elif g_path.suffix == ".pkl":
+                        with open(g_path, "rb") as f:
+                            data = pickle.load(f)
+                            # LPMM 可能会将图存储在包装类中
+                            if hasattr(data, "graph") and isinstance(data.graph, nx.Graph):
+                                nx_graph = data.graph
+                            elif isinstance(data, nx.Graph):
+                                nx_graph = data
+                    break
+                except Exception as e:
+                    logger.error(f"加载 {g_path} 失败: {e}")
+        
+        if nx_graph is None:
+            logger.warning("未找到有效的图文件。跳过图转换。")
+            return
+
+        logger.info(f"已加载图，包含 {nx_graph.number_of_nodes()} 个节点和 {nx_graph.number_of_edges()} 条边。")
+        
+        # 1. 添加节点
+        # LPMM 节点通常是哈希或带前缀的字符串。
+        # 我们需要将它们映射到 A_memorix 格式。
+        # 如果 LPMM 使用 "entity-HASH"，则与 A_memorix 匹配。
+        
+        nodes_to_add = []
+        node_attrs = {}
+        
+        for node, attrs in nx_graph.nodes(data=True):
+            # 假设 LPMM 使用一致的命名 "entity-..." 或 "paragraph-..."
+            mapped_node = self._map_node_id(node)
+            nodes_to_add.append(mapped_node)
+            if attrs:
+                node_attrs[mapped_node] = attrs
+        
+        self.graph_store.add_nodes(nodes_to_add, node_attrs)
+        
+        # 2. 添加边
+        edges_to_add = []
+        weights = []
+        
+        for u, v, data in nx_graph.edges(data=True):
+            weight = data.get("weight", 1.0)
+            edges_to_add.append((self._map_node_id(u), self._map_node_id(v)))
+            weights.append(float(weight))
+            
+            # 如果可能，将关系同步到 MetadataStore
+            # 但图的边并不总是包含关系谓词
+            # 如果 LPMM 边数据有 'predicate'，我们可以添加到元数据
+            # 通常 LPMM 边是加权和，谓词信息可能在简单图中丢失
+            
+        if edges_to_add:
+            self.graph_store.add_edges(edges_to_add, weights)
+            
+        self.graph_store.save()
+        logger.info("图转换完成。")
+
+    def run(self):
+        self.initialize_stores()
+        self.convert_vectors()
+        self.convert_graph()
+        self.metadata_store.close()
+        logger.info("所有转换成功完成。")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="将 LPMM 数据转换为 A_memorix 格式")
+    parser.add_argument("--input", "-i", required=True, help="包含 LPMM 数据的输入目录 (parquet, graphml)")
+    parser.add_argument("--output", "-o", required=True, help="A_memorix 数据的输出目录")
+    parser.add_argument("--dim", type=int, default=384, help="Embedding 维度 (必须与 LPMM 模型匹配)")
+    parser.add_argument("--batch-size", type=int, default=1024, help="Parquet 分批读取大小 (默认 1024)")
+    
+    args = parser.parse_args()
+    
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    
+    if not input_path.exists():
+        logger.error(f"输入目录不存在: {input_path}")
+        sys.exit(1)
+        
+    converter = LPMMConverter(
+        input_path,
+        output_path,
+        dimension=args.dim,
+        batch_size=args.batch_size,
+    )
+    converter.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
稳定性补丁：版本号升级至 0.3.1，加入 LPMM 转换与安全性修复。
新增 scripts/convert_lpmm.py，支持从 parquet/graph 直接转换为 A_Memorix（跳过关系向量以避免元数据不一致）。 将 AutoImporter.import_json_data 改为公开方法，并改进 import_lpmm_json.py，提供导入进度提示及更稳定的 JSON 导入流程。 在 metadata_store 与 delete_knowledge.py 中强化删除逻辑，引入 relation_prune_ops（精确的关系哈希裁剪）、更保守的孤立实体清理策略，并通过读取真实向量维度避免向量污染。 更新插件元数据、README 与 changelog