### PR TITLE
v0.6.0:新增 Web Import 管理器以及LPMM转换脚本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # 更新日志 (Changelog)
 
+## [0.6.0] - 2026-03-02
+
+本次 `0.6.0` 为中版本升级，主线是 **Web Import 导入中心上线与脚本能力对齐**、**失败重试机制升级**、**删除后 manifest 同步** 与 **导入链路稳定性增强**。
+
+### 🔖 版本信息
+
+- 插件版本：`0.5.1` → `0.6.0`
+- 配置版本：`4.0.1` → `4.1.0`
+
+### 🚀 重点能力
+
+- 新增 Web Import 导入中心（`/import`）：
+  - 上传/粘贴/本地扫描/LPMM OpenIE/LPMM 转换/时序回填/MaiBot 迁移。
+  - 任务/文件/分块三级状态展示，支持取消与失败重试。
+  - 导入文档弹窗读取（远程优先，失败回退本地）。
+- 失败重试升级为“分块优先 + 文件回退”：
+  - `POST /api/import/tasks/{task_id}/retry_failed` 保持原路径，语义升级。
+  - 支持对 `extracting` 失败分块进行子集重试。
+  - `writing`/JSON 解析失败自动回退为文件级重试。
+- 删除后 manifest 同步失效：
+  - 覆盖 `/api/source/batch_delete` 与 `/api/source`。
+  - 返回 `manifest_cleanup` 明细，避免误命中去重跳过重导入。
+
+### 📂 变更文件清单（本次发布）
+
+新增文件：
+
+- `core/utils/web_import_manager.py`
+- `scripts/migrate_maibot_memory.py`
+- `web/import.html`
+
+修改文件：
+
+- `CHANGELOG.md`
+- `CONFIG_REFERENCE.md`
+- `IMPORT_GUIDE.md`
+- `QUICK_START.md`
+- `README.md`
+- `__init__.py`
+- `_manifest.json`
+- `components/commands/debug_server_command.py`
+- `core/embedding/api_adapter.py`
+- `core/storage/graph_store.py`
+- `core/utils/summary_importer.py`
+- `plugin.py`
+- `requirements.txt`
+- `server.py`
+- `web/index.html`
+
+删除文件：
+
+- 无
+
+### 📚 文档同步
+
+- 同步更新 `README.md`、`QUICK_START.md`、`CONFIG_REFERENCE.md`、`IMPORT_GUIDE.md` 与本日志。
+- `IMPORT_GUIDE.md` 新增 “Web Import 导入中心” 专区，统一说明能力范围、状态语义与安全边界。
+
 ## [0.5.1] - 2026-02-23
 
 本次 `0.5.1` 为热修订小版本，重点修复“随主程序启动的后台任务拉起”“空名单过滤语义”以及“知识抽取模型选择”。

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -219,7 +219,7 @@ enabled = true
 - `YYYY/MM/DD`
 - `YYYY/MM/DD HH:mm`
 
-### 3.3 人物画像（v0.5.0 主更新）
+### 3.3 人物画像（v0.5.0）
 
 查询人物画像：
 
@@ -248,6 +248,23 @@ enabled = true
 `http://localhost:8082`
 
 可在 `plugins/A_memorix/config.toml` 的 `[web]` 里改端口和绑定地址。
+
+### 3.5 Web Import 导入中心（v0.6.0 新增）
+
+在可视化服务启动后，直接访问：
+
+`http://localhost:8082/import`
+
+导入中心支持：
+
+- 上传文件 / 粘贴导入
+- 本地扫描（alias + relative_path）
+- LPMM OpenIE 导入
+- LPMM 二进制转换（staging + switch）
+- 时序回填
+- MaiBot 迁移
+
+并可查看任务/文件/分块三级状态，支持取消与“重试失败项（分块优先）”。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A_Memorix
 
-**轻量级知识图谱插件** - 基于双路检索 + 人物画像的独立记忆增强系统 (v0.5.1)
+**轻量级知识图谱插件** - 基于双路检索 + 人物画像的独立记忆增强系统 (v0.6.0)
 
 > 消えていかない感覚 , まだまだ足りてないみたい !
 
@@ -9,16 +9,11 @@
 > 升级后，虽然系统会尝试自动迁移部分数据，但为确保知识图谱的检索精度和完整性，强烈建议在升级后使用 `process_knowledge.py` 脚本重新导入原始文本。
 
 > [!NOTE]
-> **v0.5.0 人物画像增强（主更新）**：
-> 1. 新增 `PersonProfileService`，基于“别名解析 + 图关系证据 + 向量证据”生成人物画像快照；
-> 2. 新增 `/person_profile on|off|status`，支持按 `stream_id + user_id` 控制画像注入；
-> 3. `knowledge_query` 新增 `query_type=person`，`/query person|p` 支持人物画像查询；
-> 4. 新增画像定时刷新任务与 override/快照存储能力（依赖 metadata 新表）。
-> 
-> **v0.5.1 版本与Schema同步**：
-> 1. 插件版本升级到 `0.5.1`；
-> 2. 配置版本升级到 `4.0.1`；
-> 3. `manifest_version` 保持为 `1`（兼容当前仅支持 v1 的宿主校验器）。
+> **v0.6.0 导入能力与WebUI增强**：
+> 1. 新增 Web Import 导入中心（`/import`），支持上传/粘贴/本地扫描/LPMM OpenIE/LPMM转换/时序回填/MaiBot 迁移；
+> 2. 导入状态细化到任务/文件/分块级，支持取消与“失败项重试（分块优先 + 文件回退）”；
+> 3. 导入期间写操作保护、删除后 manifest 同步失效、导入文档弹窗与中文状态展示已对齐。
+
 
 ## 📑 文档索引
 
@@ -32,8 +27,9 @@
 ## ✨ 特性
 
 - **🧠 双路检索** - 关系图谱 + 向量语义并行检索，结合 Personalized PageRank 智能排序。
-- **⏱️ 时序检索（分钟级）** - 支持 `time/hybrid` 模式，按事件时间区间命中并可回退 `created_at`。
-- **👤 人物画像（v0.5.1）** - 支持人物画像快照、别名解析、手工覆盖、按会话 opt-in 注入控制。
+- **⏱️ 时序检索（v0.5.0）** - 支持 `time/hybrid` 模式，按事件时间区间命中并可回退 `created_at`。
+- **👤 人物画像（v0.5.0）** - 支持人物画像快照、别名解析、手工覆盖、按会话 opt-in 注入控制。
+- **📥 Web Import 导入中心（v0.6.0）** - 提供统一导入控制台（`/import`），支持上传/粘贴/路径扫描/LPMM 迁移与任务级可观测。
 - **🧩 稀疏检索增强（FTS5 + BM25）** - embedding 不可用或召回偏弱时自动走 sparse，支持 `jieba/mixed/char_2gram` 分词与 `ngram` 倒排回退。
 - **🧬 生物学记忆 (V5)** - 模拟人类记忆的**衰减 (Decay)**、**强化 (Reinforce)** 与 **结构化重组 (Prune)** 机制，实现记忆的动态生命周期管理。
 - **🔄 智能回退** - 当直接检索结果弱时，自动触发多跳路径搜索，增强间接关系召回。
@@ -69,7 +65,9 @@ pip install -r requirements.txt
 - `tenacity` (重试机制)
 - `nest-asyncio` (环境兼容)
 - `jieba` (稀疏检索中文分词；未安装时自动回退 char n-gram)
+- `networkx`, `pyarrow`, `pandas` (LPMM 转换链路)
 - `fastapi`, `uvicorn`, `pydantic` (可视化服务器)
+- `python-multipart` (Web 上传解析)
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ A_Memorix - 轻量级知识库插件
 完全独立的记忆增强系统，优化低资源环境下的知识存储与检索。
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __author__ = "A_Dawn"
 
 from .plugin import A_MemorixPlugin

--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "A_Memorix",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "轻量级知识库插件 - 基于双路检索与人物画像的独立记忆增强系统，优化低资源环境下的知识存储与检索",
   "author": {
     "name": "A_Dawn"
@@ -332,6 +332,56 @@
         "type": "string",
         "default": "0.0.0.0",
         "description": "服务器绑定地址"
+      },
+      "import": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "max_queue_size": {
+            "type": "integer",
+            "default": 20
+          },
+          "max_files_per_task": {
+            "type": "integer",
+            "default": 200
+          },
+          "max_file_size_mb": {
+            "type": "integer",
+            "default": 20
+          },
+          "max_paste_chars": {
+            "type": "integer",
+            "default": 200000
+          },
+          "default_file_concurrency": {
+            "type": "integer",
+            "default": 2
+          },
+          "default_chunk_concurrency": {
+            "type": "integer",
+            "default": 4
+          },
+          "max_file_concurrency": {
+            "type": "integer",
+            "default": 6
+          },
+          "max_chunk_concurrency": {
+            "type": "integer",
+            "default": 12
+          },
+          "poll_interval_ms": {
+            "type": "integer",
+            "default": 1000
+          },
+          "token": {
+            "type": "string",
+            "default": ""
+          }
+        },
+        "description": "Web 导入中心配置（队列、并发、大小限制、鉴权）"
       }
     },
     "advanced": {
@@ -560,11 +610,15 @@
     "required": [
       "numpy>=1.20.0",
       "scipy>=1.7.0",
+      "networkx>=3.0.0",
+      "pyarrow>=10.0.0",
+      "pandas>=1.5.0",
       "nest-asyncio>=1.5.0",
       "faiss-cpu>=1.7.0",
       "fastapi>=0.100.0",
       "uvicorn>=0.20.0",
-      "pydantic>=2.0.0"
+      "pydantic>=2.0.0",
+      "python-multipart>=0.0.9"
     ],
     "optional": []
   },

--- a/components/commands/debug_server_command.py
+++ b/components/commands/debug_server_command.py
@@ -20,7 +20,16 @@ class DebugServerCommand(BaseCommand):
             status = []
             status.append(f"Plugin initialized: {plugin._initialized}")
             status.append(f"Server instance: {plugin.server}")
-            
+
+            # 先确保核心存储已初始化，避免只启动了 WebUI 但导入依赖为空
+            if not getattr(plugin, "_initialized", False):
+                status.append("Storage not initialized, trying _sync_initialize() ...")
+                try:
+                    plugin._sync_initialize()
+                    status.append(f"Storage initialized: {plugin._initialized}")
+                except Exception as e:
+                    status.append(f"❌ _sync_initialize failed: {e}")
+
             # 尝试强制启动
             if not plugin.server:
                 status.append("Attempting to start server...")

--- a/core/utils/web_import_manager.py
+++ b/core/utils/web_import_manager.py
@@ -1,0 +1,3532 @@
+"""
+Web Import Task Manager
+
+为 A_Memorix WebUI 提供导入任务队列、状态管理、并发调度与取消/重试能力。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from src.common.logger import get_logger
+from src.plugin_system.apis import llm_api
+
+from ..storage import detect_knowledge_type, KnowledgeType, MetadataStore
+from ..utils.time_parser import normalize_time_meta
+from ..strategies.base import ProcessedChunk, KnowledgeType as StrategyKnowledgeType
+from ..strategies.narrative import NarrativeStrategy
+from ..strategies.factual import FactualStrategy
+from ..strategies.quote import QuoteStrategy
+
+logger = get_logger("A_Memorix.WebImportManager")
+
+
+TASK_STATUS = {
+    "queued",
+    "preparing",
+    "running",
+    "cancel_requested",
+    "cancelled",
+    "completed",
+    "completed_with_errors",
+    "failed",
+}
+
+FILE_STATUS = {
+    "queued",
+    "preparing",
+    "splitting",
+    "extracting",
+    "writing",
+    "saving",
+    "completed",
+    "failed",
+    "cancelled",
+}
+
+CHUNK_STATUS = {
+    "queued",
+    "extracting",
+    "writing",
+    "completed",
+    "failed",
+    "cancelled",
+}
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", ""}:
+        return False
+    return default
+
+
+def _clamp(value: int, min_value: int, max_value: int) -> int:
+    return max(min_value, min(max_value, value))
+
+
+def _coerce_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        raw_items = value
+    else:
+        text = str(value or "").replace("\r", "\n")
+        raw_items = []
+        for seg in text.split("\n"):
+            raw_items.extend(seg.split(","))
+
+    out: List[str] = []
+    seen = set()
+    for item in raw_items:
+        v = str(item or "").strip()
+        if not v:
+            continue
+        key = v.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(v)
+    return out
+
+
+def _parse_optional_positive_int(value: Any, field_name: str) -> Optional[int]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text == "":
+        return None
+    try:
+        parsed = int(text)
+    except Exception:
+        raise ValueError(f"{field_name} 必须为整数")
+    if parsed <= 0:
+        raise ValueError(f"{field_name} 必须 > 0")
+    return parsed
+
+
+def _safe_filename(name: str) -> str:
+    base = os.path.basename(str(name or "").strip())
+    if not base:
+        return f"unnamed_{uuid.uuid4().hex[:8]}.txt"
+    return base
+
+
+def _storage_type_from_strategy(strategy_type: StrategyKnowledgeType) -> str:
+    if strategy_type == StrategyKnowledgeType.NARRATIVE:
+        return KnowledgeType.NARRATIVE.value
+    if strategy_type == StrategyKnowledgeType.FACTUAL:
+        return KnowledgeType.FACTUAL.value
+    return KnowledgeType.MIXED.value
+
+
+@dataclass
+class ImportChunkRecord:
+    chunk_id: str
+    index: int
+    chunk_type: str
+    status: str = "queued"
+    step: str = "queued"
+    failed_at: str = ""
+    retryable: bool = False
+    error: str = ""
+    progress: float = 0.0
+    content_preview: str = ""
+    updated_at: float = field(default_factory=_now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "chunk_id": self.chunk_id,
+            "index": self.index,
+            "chunk_type": self.chunk_type,
+            "status": self.status,
+            "step": self.step,
+            "failed_at": self.failed_at,
+            "retryable": self.retryable,
+            "error": self.error,
+            "progress": self.progress,
+            "content_preview": self.content_preview,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class ImportFileRecord:
+    file_id: str
+    name: str
+    source_kind: str
+    input_mode: str
+    status: str = "queued"
+    current_step: str = "queued"
+    detected_strategy_type: str = "unknown"
+    total_chunks: int = 0
+    done_chunks: int = 0
+    failed_chunks: int = 0
+    cancelled_chunks: int = 0
+    progress: float = 0.0
+    error: str = ""
+    chunks: List[ImportChunkRecord] = field(default_factory=list)
+    created_at: float = field(default_factory=_now)
+    updated_at: float = field(default_factory=_now)
+    temp_path: Optional[str] = None
+    source_path: Optional[str] = None
+    inline_content: Optional[str] = None
+    content_hash: str = ""
+    retry_chunk_indexes: List[int] = field(default_factory=list)
+    retry_mode: str = ""
+
+    def to_dict(self, include_chunks: bool = False) -> Dict[str, Any]:
+        payload = {
+            "file_id": self.file_id,
+            "name": self.name,
+            "source_kind": self.source_kind,
+            "input_mode": self.input_mode,
+            "status": self.status,
+            "current_step": self.current_step,
+            "detected_strategy_type": self.detected_strategy_type,
+            "total_chunks": self.total_chunks,
+            "done_chunks": self.done_chunks,
+            "failed_chunks": self.failed_chunks,
+            "cancelled_chunks": self.cancelled_chunks,
+            "progress": self.progress,
+            "error": self.error,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "source_path": self.source_path or "",
+            "content_hash": self.content_hash or "",
+            "retry_chunk_indexes": list(self.retry_chunk_indexes or []),
+            "retry_mode": self.retry_mode or "",
+        }
+        if include_chunks:
+            payload["chunks"] = [chunk.to_dict() for chunk in self.chunks]
+        return payload
+
+
+@dataclass
+class ImportTaskRecord:
+    task_id: str
+    source: str
+    params: Dict[str, Any]
+    status: str = "queued"
+    current_step: str = "queued"
+    total_chunks: int = 0
+    done_chunks: int = 0
+    failed_chunks: int = 0
+    cancelled_chunks: int = 0
+    progress: float = 0.0
+    error: str = ""
+    files: List[ImportFileRecord] = field(default_factory=list)
+    created_at: float = field(default_factory=_now)
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    updated_at: float = field(default_factory=_now)
+    schema_detected: str = ""
+    artifact_paths: Dict[str, str] = field(default_factory=dict)
+    rollback_info: Dict[str, Any] = field(default_factory=dict)
+    retry_parent_task_id: str = ""
+    retry_summary: Dict[str, Any] = field(default_factory=dict)
+
+    def to_summary(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "source": self.source,
+            "status": self.status,
+            "current_step": self.current_step,
+            "total_chunks": self.total_chunks,
+            "done_chunks": self.done_chunks,
+            "failed_chunks": self.failed_chunks,
+            "cancelled_chunks": self.cancelled_chunks,
+            "progress": self.progress,
+            "error": self.error,
+            "file_count": len(self.files),
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "updated_at": self.updated_at,
+            "task_kind": str(self.params.get("task_kind") or self.source),
+            "schema_detected": self.schema_detected,
+            "artifact_paths": dict(self.artifact_paths),
+            "rollback_info": dict(self.rollback_info),
+            "retry_parent_task_id": self.retry_parent_task_id or "",
+            "retry_summary": dict(self.retry_summary),
+        }
+
+    def to_detail(self, include_chunks: bool = False) -> Dict[str, Any]:
+        payload = self.to_summary()
+        payload["params"] = self.params
+        payload["files"] = [f.to_dict(include_chunks=include_chunks) for f in self.files]
+        return payload
+
+
+class ImportTaskManager:
+    def __init__(self, plugin: Any):
+        self.plugin = plugin
+        self._lock = asyncio.Lock()
+        self._storage_lock = asyncio.Lock()
+
+        self._tasks: Dict[str, ImportTaskRecord] = {}
+        self._task_order: deque[str] = deque()
+        self._queue: deque[str] = deque()
+        self._active_task_id: Optional[str] = None
+
+        self._worker_task: Optional[asyncio.Task] = None
+        self._stopping = False
+
+        self._temp_root = self._resolve_temp_root()
+        self._temp_root.mkdir(parents=True, exist_ok=True)
+        self._reports_root = self._resolve_reports_root()
+        self._reports_root.mkdir(parents=True, exist_ok=True)
+        self._manifest_path = self._resolve_manifest_path()
+        self._manifest_cache: Optional[Dict[str, Any]] = None
+        self._write_changed_callback: Optional[Callable[[Dict[str, Any]], Any]] = None
+
+    def set_write_changed_callback(self, callback: Optional[Callable[[Dict[str, Any]], Any]]) -> None:
+        self._write_changed_callback = callback
+
+    async def _notify_write_changed(self, payload: Dict[str, Any]) -> None:
+        callback = self._write_changed_callback
+        if callback is None:
+            return
+        try:
+            maybe_awaitable = callback(payload)
+            if asyncio.iscoroutine(maybe_awaitable):
+                await maybe_awaitable
+        except Exception as e:
+            logger.warning(f"写入变更回调执行失败: {e}")
+
+    def _resolve_temp_root(self) -> Path:
+        data_dir = Path(self.plugin.get_config("storage.data_dir", "./data"))
+        if str(data_dir).startswith("."):
+            plugin_dir = Path(__file__).resolve().parents[2]
+            data_dir = (plugin_dir / data_dir).resolve()
+        return data_dir / "web_import_tmp"
+
+    def _resolve_reports_root(self) -> Path:
+        return self._resolve_data_dir() / "web_import_reports"
+
+    def _resolve_manifest_path(self) -> Path:
+        return self._resolve_data_dir() / "import_manifest.json"
+
+    def _resolve_staging_root(self) -> Path:
+        return self._resolve_data_dir() / "import_staging"
+
+    def _resolve_backup_root(self) -> Path:
+        return self._resolve_data_dir() / "import_backup"
+
+    def _resolve_repo_root(self) -> Path:
+        return Path(__file__).resolve().parents[4]
+
+    def _resolve_data_dir(self) -> Path:
+        data_dir = Path(self.plugin.get_config("storage.data_dir", "./data"))
+        if str(data_dir).startswith("."):
+            plugin_dir = Path(__file__).resolve().parents[2]
+            data_dir = (plugin_dir / data_dir).resolve()
+        return data_dir.resolve()
+
+    def _resolve_migration_script(self) -> Path:
+        return Path(__file__).resolve().parents[2] / "scripts" / "migrate_maibot_memory.py"
+
+    def _default_maibot_source_db(self) -> Path:
+        # plugins/A_memorix/core/utils -> repo root = parents[4]
+        return Path(__file__).resolve().parents[4] / "data" / "MaiBot.db"
+
+    def _cfg(self, key: str, default: Any) -> Any:
+        return self.plugin.get_config(key, default)
+
+    def _cfg_int(self, key: str, default: int) -> int:
+        return _coerce_int(self._cfg(key, default), default)
+
+    def _is_enabled(self) -> bool:
+        return bool(self._cfg("web.import.enabled", True))
+
+    def _queue_limit(self) -> int:
+        return max(1, self._cfg_int("web.import.max_queue_size", 20))
+
+    def _max_files_per_task(self) -> int:
+        return max(1, self._cfg_int("web.import.max_files_per_task", 200))
+
+    def _max_file_size_bytes(self) -> int:
+        mb = max(1, self._cfg_int("web.import.max_file_size_mb", 20))
+        return mb * 1024 * 1024
+
+    def _max_paste_chars(self) -> int:
+        return max(1000, self._cfg_int("web.import.max_paste_chars", 200000))
+
+    def _default_file_concurrency(self) -> int:
+        return max(1, self._cfg_int("web.import.default_file_concurrency", 2))
+
+    def _default_chunk_concurrency(self) -> int:
+        return max(1, self._cfg_int("web.import.default_chunk_concurrency", 4))
+
+    def _max_file_concurrency(self) -> int:
+        return max(1, self._cfg_int("web.import.max_file_concurrency", 6))
+
+    def _max_chunk_concurrency(self) -> int:
+        return max(1, self._cfg_int("web.import.max_chunk_concurrency", 12))
+
+    def _llm_retry_config(self) -> Dict[str, float]:
+        retries = max(0, self._cfg_int("web.import.llm_retry.max_attempts", 4))
+        min_wait = max(0.1, float(self._cfg("web.import.llm_retry.min_wait_seconds", 3) or 3))
+        max_wait = max(min_wait, float(self._cfg("web.import.llm_retry.max_wait_seconds", 40) or 40))
+        mult = max(1.0, float(self._cfg("web.import.llm_retry.backoff_multiplier", 3) or 3))
+        return {
+            "retries": retries,
+            "min_wait": min_wait,
+            "max_wait": max_wait,
+            "multiplier": mult,
+        }
+
+    def _default_path_aliases(self) -> Dict[str, str]:
+        plugin_dir = Path(__file__).resolve().parents[2]
+        repo_root = self._resolve_repo_root()
+        return {
+            "raw": str((plugin_dir / "data" / "raw").resolve()),
+            "lpmm": str((repo_root / "data" / "lpmm_storage").resolve()),
+            "plugin_data": str((plugin_dir / "data").resolve()),
+        }
+
+    def get_path_aliases(self) -> Dict[str, str]:
+        configured = self._cfg("web.import.path_aliases", self._default_path_aliases())
+        if not isinstance(configured, dict):
+            configured = self._default_path_aliases()
+
+        repo_root = self._resolve_repo_root()
+        result: Dict[str, str] = {}
+        for alias, raw_path in configured.items():
+            key = str(alias or "").strip()
+            if not key:
+                continue
+            text = str(raw_path or "").strip()
+            if not text:
+                continue
+            if text.startswith("\\\\"):
+                continue
+            p = Path(text)
+            if not p.is_absolute():
+                p = (repo_root / p).resolve()
+            else:
+                p = p.resolve()
+            result[key] = str(p)
+
+        defaults = self._default_path_aliases()
+        for key, path in defaults.items():
+            result.setdefault(key, path)
+        return result
+
+    def resolve_path_alias(
+        self,
+        alias: str,
+        relative_path: str = "",
+        *,
+        must_exist: bool = False,
+    ) -> Path:
+        alias_key = str(alias or "").strip()
+        aliases = self.get_path_aliases()
+        if alias_key not in aliases:
+            raise ValueError(f"未知路径别名: {alias_key}")
+
+        root = Path(aliases[alias_key]).resolve()
+        rel = str(relative_path or "").strip().replace("\\", "/")
+        if rel.startswith("/") or rel.startswith("\\") or rel.startswith("//"):
+            raise ValueError("relative_path 不能为绝对路径")
+        if ":" in rel:
+            raise ValueError("relative_path 不允许包含盘符")
+
+        candidate = (root / rel).resolve() if rel else root
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            raise ValueError("路径越界：relative_path 超出白名单目录")
+        if must_exist and not candidate.exists():
+            raise ValueError(f"路径不存在: {candidate}")
+        return candidate
+
+    async def resolve_path_request(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        alias = str(payload.get("alias") or "").strip()
+        relative_path = str(payload.get("relative_path") or "").strip()
+        must_exist = _coerce_bool(payload.get("must_exist"), True)
+        resolved = self.resolve_path_alias(alias, relative_path, must_exist=must_exist)
+        return {
+            "alias": alias,
+            "relative_path": relative_path,
+            "resolved_path": str(resolved),
+            "exists": resolved.exists(),
+            "is_file": resolved.is_file(),
+            "is_dir": resolved.is_dir(),
+        }
+
+    def _load_manifest(self) -> Dict[str, Any]:
+        if self._manifest_cache is not None:
+            return self._manifest_cache
+        path = self._manifest_path
+        if not path.exists():
+            self._manifest_cache = {}
+            return self._manifest_cache
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                self._manifest_cache = payload
+            else:
+                self._manifest_cache = {}
+        except Exception:
+            self._manifest_cache = {}
+        return self._manifest_cache
+
+    def _save_manifest(self, payload: Dict[str, Any]) -> None:
+        path = self._manifest_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        self._manifest_cache = payload
+
+    def _clear_manifest(self) -> None:
+        self._save_manifest({})
+
+    def _normalize_manifest_path(self, raw_path: str) -> str:
+        text = str(raw_path or "").strip()
+        if not text:
+            return ""
+        return text.replace("\\", "/").strip().lower()
+
+    def _match_manifest_item_for_source(self, source: str, item: Dict[str, Any]) -> bool:
+        source_text = str(source or "").strip()
+        if not source_text or ":" not in source_text:
+            return False
+        prefix, tail = source_text.split(":", 1)
+        source_kind = prefix.strip().lower()
+        source_value = tail.strip()
+        if not source_value:
+            return False
+
+        item_kind = str(item.get("source_kind") or "").strip().lower()
+        item_name = str(item.get("name") or "").strip()
+        item_path_norm = self._normalize_manifest_path(item.get("source_path") or "")
+
+        if source_kind in {"raw_scan", "lpmm_openie"}:
+            source_path_norm = self._normalize_manifest_path(source_value)
+            if source_path_norm and item_path_norm and source_path_norm == item_path_norm and item_kind == source_kind:
+                return True
+
+        if source_kind == "web_import":
+            return item_kind in {"upload", "paste"} and item_name == source_value
+
+        if source_kind == "lpmm_openie":
+            source_name = Path(source_value).name
+            return item_kind == "lpmm_openie" and item_name == source_name
+
+        return False
+
+    async def invalidate_manifest_for_sources(self, sources: List[str]) -> Dict[str, Any]:
+        requested_sources: List[str] = []
+        seen_sources = set()
+        for raw in sources or []:
+            source = str(raw or "").strip()
+            if not source:
+                continue
+            key = source.lower()
+            if key in seen_sources:
+                continue
+            seen_sources.add(key)
+            requested_sources.append(source)
+
+        result: Dict[str, Any] = {
+            "requested_sources": requested_sources,
+            "removed_count": 0,
+            "removed_keys": [],
+            "remaining_count": 0,
+            "unmatched_sources": [],
+            "warnings": [],
+        }
+
+        async with self._lock:
+            manifest = self._load_manifest()
+            if not isinstance(manifest, dict):
+                manifest = {}
+
+            valid_items: List[Tuple[str, Dict[str, Any]]] = []
+            malformed_keys: List[str] = []
+            for key, item in manifest.items():
+                if isinstance(item, dict):
+                    valid_items.append((str(key), item))
+                else:
+                    malformed_keys.append(str(key))
+
+            keys_to_remove = set()
+            for source in requested_sources:
+                matched = False
+                for key, item in valid_items:
+                    if self._match_manifest_item_for_source(source, item):
+                        keys_to_remove.add(key)
+                        matched = True
+                if not matched:
+                    result["unmatched_sources"].append(source)
+
+            if keys_to_remove:
+                for key in keys_to_remove:
+                    manifest.pop(key, None)
+                self._save_manifest(manifest)
+
+            result["removed_keys"] = sorted(keys_to_remove)
+            result["removed_count"] = len(keys_to_remove)
+            result["remaining_count"] = len(manifest)
+
+            if malformed_keys:
+                preview = ", ".join(malformed_keys[:5])
+                extra = "" if len(malformed_keys) <= 5 else f" ... (+{len(malformed_keys) - 5})"
+                result["warnings"].append(
+                    f"manifest 条目结构异常，已跳过 {len(malformed_keys)} 项: {preview}{extra}"
+                )
+
+        return result
+
+    def _manifest_key_for_file(self, file_record: ImportFileRecord, content_hash: str, dedupe_policy: str) -> str:
+        if dedupe_policy == "content_hash":
+            return f"hash:{content_hash}"
+        if file_record.source_path:
+            return f"path:{Path(file_record.source_path).as_posix().lower()}"
+        return f"hash:{content_hash}"
+
+    def _is_manifest_hit(
+        self,
+        file_record: ImportFileRecord,
+        content_hash: str,
+        dedupe_policy: str,
+    ) -> bool:
+        key = self._manifest_key_for_file(file_record, content_hash, dedupe_policy)
+        manifest = self._load_manifest()
+        item = manifest.get(key)
+        if not isinstance(item, dict):
+            return False
+        return str(item.get("hash") or "") == content_hash and bool(item.get("imported"))
+
+    def _record_manifest_import(
+        self,
+        file_record: ImportFileRecord,
+        content_hash: str,
+        dedupe_policy: str,
+        task_id: str,
+    ) -> None:
+        key = self._manifest_key_for_file(file_record, content_hash, dedupe_policy)
+        manifest = self._load_manifest()
+        manifest[key] = {
+            "hash": content_hash,
+            "imported": True,
+            "timestamp": _now(),
+            "task_id": task_id,
+            "name": file_record.name,
+            "source_path": file_record.source_path or "",
+            "source_kind": file_record.source_kind,
+        }
+        self._save_manifest(manifest)
+
+    def _normalize_common_import_params(self, payload: Dict[str, Any], *, default_dedupe: str) -> Dict[str, Any]:
+        input_mode = str(payload.get("input_mode", "text") or "text").strip().lower()
+        if input_mode not in {"text", "json"}:
+            raise ValueError("input_mode 必须为 text 或 json")
+
+        file_concurrency = _coerce_int(
+            payload.get("file_concurrency", self._default_file_concurrency()),
+            self._default_file_concurrency(),
+        )
+        chunk_concurrency = _coerce_int(
+            payload.get("chunk_concurrency", self._default_chunk_concurrency()),
+            self._default_chunk_concurrency(),
+        )
+        file_concurrency = _clamp(file_concurrency, 1, self._max_file_concurrency())
+        chunk_concurrency = _clamp(chunk_concurrency, 1, self._max_chunk_concurrency())
+
+        llm_enabled = _coerce_bool(payload.get("llm_enabled", True), True)
+        strategy_override = str(payload.get("strategy_override", "auto") or "auto").strip().lower()
+        if strategy_override not in {"auto", "narrative", "factual", "quote"}:
+            raise ValueError("strategy_override 必须为 auto/narrative/factual/quote")
+
+        dedupe_policy = str(payload.get("dedupe_policy", default_dedupe) or default_dedupe).strip().lower()
+        if dedupe_policy not in {"content_hash", "manifest", "none"}:
+            raise ValueError("dedupe_policy 必须为 content_hash/manifest/none")
+
+        chat_log = _coerce_bool(payload.get("chat_log"), False)
+        chat_reference_time = str(payload.get("chat_reference_time") or "").strip() or None
+        force = _coerce_bool(payload.get("force"), False)
+        clear_manifest = _coerce_bool(payload.get("clear_manifest"), False)
+
+        return {
+            "input_mode": input_mode,
+            "file_concurrency": file_concurrency,
+            "chunk_concurrency": chunk_concurrency,
+            "llm_enabled": llm_enabled,
+            "strategy_override": strategy_override,
+            "chat_log": chat_log,
+            "chat_reference_time": chat_reference_time,
+            "force": force,
+            "clear_manifest": clear_manifest,
+            "dedupe_policy": dedupe_policy,
+        }
+
+    def _normalize_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._normalize_common_import_params(payload, default_dedupe="content_hash")
+        params["task_kind"] = "upload"
+        return params
+
+    def _normalize_raw_scan_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._normalize_common_import_params(payload, default_dedupe="manifest")
+        alias = str(payload.get("alias") or "raw").strip()
+        relative_path = str(payload.get("relative_path") or "").strip()
+        glob_pattern = str(payload.get("glob") or "*").strip() or "*"
+        recursive = _coerce_bool(payload.get("recursive"), True)
+        if ".." in relative_path.replace("\\", "/").split("/"):
+            raise ValueError("relative_path 不允许包含 ..")
+        params.update(
+            {
+                "task_kind": "raw_scan",
+                "alias": alias,
+                "relative_path": relative_path,
+                "glob": glob_pattern,
+                "recursive": recursive,
+            }
+        )
+        return params
+
+    def _normalize_lpmm_openie_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._normalize_common_import_params(payload, default_dedupe="manifest")
+        alias = str(payload.get("alias") or "lpmm").strip()
+        relative_path = str(payload.get("relative_path") or "").strip()
+        include_all_json = _coerce_bool(payload.get("include_all_json"), False)
+        params.update(
+            {
+                "task_kind": "lpmm_openie",
+                "alias": alias,
+                "relative_path": relative_path,
+                "include_all_json": include_all_json,
+                "input_mode": "json",
+            }
+        )
+        return params
+
+    def _normalize_temporal_backfill_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        alias = str(payload.get("alias") or "plugin_data").strip()
+        relative_path = str(payload.get("relative_path") or "").strip()
+        dry_run = _coerce_bool(payload.get("dry_run"), False)
+        no_created_fallback = _coerce_bool(payload.get("no_created_fallback"), False)
+        limit = _parse_optional_positive_int(payload.get("limit"), "limit") or 100000
+        return {
+            "task_kind": "temporal_backfill",
+            "alias": alias,
+            "relative_path": relative_path,
+            "dry_run": dry_run,
+            "no_created_fallback": no_created_fallback,
+            "limit": limit,
+        }
+
+    def _normalize_lpmm_convert_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        alias = str(payload.get("alias") or "lpmm").strip()
+        relative_path = str(payload.get("relative_path") or "").strip()
+        target_alias = str(payload.get("target_alias") or "plugin_data").strip()
+        target_relative_path = str(payload.get("target_relative_path") or "").strip()
+        dimension = _parse_optional_positive_int(payload.get("dimension"), "dimension") or _coerce_int(
+            self._cfg("embedding.dimension", 384),
+            384,
+        )
+        batch_size = _parse_optional_positive_int(payload.get("batch_size"), "batch_size") or 1024
+        return {
+            "task_kind": "lpmm_convert",
+            "alias": alias,
+            "relative_path": relative_path,
+            "target_alias": target_alias,
+            "target_relative_path": target_relative_path,
+            "dimension": dimension,
+            "batch_size": batch_size,
+        }
+
+    def _normalize_by_task_kind(self, task_kind: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        kind = str(task_kind or "").strip().lower()
+        if kind in {"upload", "paste"}:
+            params = self._normalize_params(payload)
+            params["task_kind"] = kind
+            return params
+        if kind == "maibot_migration":
+            return self._normalize_migration_params(payload)
+        if kind == "raw_scan":
+            return self._normalize_raw_scan_params(payload)
+        if kind == "lpmm_openie":
+            return self._normalize_lpmm_openie_params(payload)
+        if kind == "temporal_backfill":
+            return self._normalize_temporal_backfill_params(payload)
+        if kind == "lpmm_convert":
+            return self._normalize_lpmm_convert_params(payload)
+        # upload/paste 默认走通用文本导入参数
+        return self._normalize_params(payload)
+
+    def _normalize_migration_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        source_db = str(payload.get("source_db") or "").strip()
+        if not source_db:
+            source_db = str(self._default_maibot_source_db())
+
+        time_from = str(payload.get("time_from") or "").strip() or None
+        time_to = str(payload.get("time_to") or "").strip() or None
+
+        stream_ids = _coerce_list(payload.get("stream_ids"))
+        group_ids = _coerce_list(payload.get("group_ids"))
+        user_ids = _coerce_list(payload.get("user_ids"))
+
+        start_id = _parse_optional_positive_int(payload.get("start_id"), "start_id")
+        end_id = _parse_optional_positive_int(payload.get("end_id"), "end_id")
+        if start_id is not None and end_id is not None and start_id > end_id:
+            raise ValueError("start_id 不能大于 end_id")
+
+        read_batch_size = _parse_optional_positive_int(payload.get("read_batch_size"), "read_batch_size") or 2000
+        commit_window_rows = _parse_optional_positive_int(payload.get("commit_window_rows"), "commit_window_rows") or 20000
+        embed_batch_size = _parse_optional_positive_int(payload.get("embed_batch_size"), "embed_batch_size") or 256
+        entity_embed_batch_size = (
+            _parse_optional_positive_int(payload.get("entity_embed_batch_size"), "entity_embed_batch_size") or 512
+        )
+        embed_workers = _parse_optional_positive_int(payload.get("embed_workers"), "embed_workers")
+        max_errors = _parse_optional_positive_int(payload.get("max_errors"), "max_errors") or 500
+        log_every = _parse_optional_positive_int(payload.get("log_every"), "log_every") or 5000
+        preview_limit = _parse_optional_positive_int(payload.get("preview_limit"), "preview_limit") or 20
+
+        no_resume = _coerce_bool(payload.get("no_resume"), False)
+        reset_state = _coerce_bool(payload.get("reset_state"), False)
+        dry_run = _coerce_bool(payload.get("dry_run"), False)
+        verify_only = _coerce_bool(payload.get("verify_only"), False)
+
+        return {
+            "task_kind": "maibot_migration",
+            "source_db": source_db,
+            "target_data_dir": str(self._resolve_data_dir()),
+            "time_from": time_from,
+            "time_to": time_to,
+            "stream_ids": stream_ids,
+            "group_ids": group_ids,
+            "user_ids": user_ids,
+            "start_id": start_id,
+            "end_id": end_id,
+            "read_batch_size": read_batch_size,
+            "commit_window_rows": commit_window_rows,
+            "embed_batch_size": embed_batch_size,
+            "entity_embed_batch_size": entity_embed_batch_size,
+            "embed_workers": embed_workers,
+            "max_errors": max_errors,
+            "log_every": log_every,
+            "preview_limit": preview_limit,
+            "no_resume": no_resume,
+            "reset_state": reset_state,
+            "dry_run": dry_run,
+            "verify_only": verify_only,
+        }
+
+    def _pending_task_count(self) -> int:
+        pending = 0
+        for task in self._tasks.values():
+            if task.status in {"queued", "preparing", "running", "cancel_requested"}:
+                pending += 1
+        return pending
+
+    async def _ensure_worker(self) -> None:
+        async with self._lock:
+            if self._worker_task and not self._worker_task.done():
+                return
+            self._stopping = False
+            self._worker_task = asyncio.create_task(self._worker_loop())
+
+    async def get_runtime_settings(self) -> Dict[str, Any]:
+        llm_retry = self._llm_retry_config()
+        return {
+            "max_queue_size": self._queue_limit(),
+            "max_files_per_task": self._max_files_per_task(),
+            "max_file_size_mb": self._cfg_int("web.import.max_file_size_mb", 20),
+            "max_paste_chars": self._max_paste_chars(),
+            "default_file_concurrency": self._default_file_concurrency(),
+            "default_chunk_concurrency": self._default_chunk_concurrency(),
+            "max_file_concurrency": self._max_file_concurrency(),
+            "max_chunk_concurrency": self._max_chunk_concurrency(),
+            "poll_interval_ms": max(200, self._cfg_int("web.import.poll_interval_ms", 1000)),
+            "maibot_source_db_default": str(self._default_maibot_source_db()),
+            "maibot_target_data_dir": str(self._resolve_data_dir()),
+            "path_aliases": self.get_path_aliases(),
+            "llm_retry": llm_retry,
+            "convert_enable_staging_switch": _coerce_bool(
+                self._cfg("web.import.convert.enable_staging_switch", True), True
+            ),
+            "convert_keep_backup_count": max(0, self._cfg_int("web.import.convert.keep_backup_count", 3)),
+        }
+
+    def is_write_blocked(self) -> bool:
+        task_id = self._active_task_id
+        if not task_id:
+            return False
+        task = self._tasks.get(task_id)
+        if not task:
+            return False
+        return task.status in {"preparing", "running", "cancel_requested"}
+
+    def _ensure_ready(self) -> None:
+        required_attrs = ("metadata_store", "vector_store", "graph_store", "embedding_manager")
+
+        def _collect_missing() -> List[str]:
+            missing_local: List[str] = []
+            for attr in required_attrs:
+                if getattr(self.plugin, attr, None) is None:
+                    missing_local.append(attr)
+            return missing_local
+
+        missing = _collect_missing()
+        if missing:
+            sync_init = getattr(self.plugin, "_sync_initialize", None)
+            if callable(sync_init):
+                try:
+                    # 懒初始化兜底，兼容 Web 先启动、存储后初始化的场景
+                    sync_init()
+                except Exception as e:
+                    logger.warning(f"导入依赖懒初始化失败: {e}")
+                missing = _collect_missing()
+
+        if missing:
+            raise ValueError(f"导入依赖未初始化: {', '.join(missing)}")
+
+    def _scan_files(
+        self,
+        base_path: Path,
+        *,
+        recursive: bool,
+        glob_pattern: str,
+        allowed_exts: Optional[set[str]] = None,
+    ) -> List[Path]:
+        if base_path.is_file():
+            candidates = [base_path]
+        else:
+            if recursive:
+                candidates = list(base_path.rglob(glob_pattern))
+            else:
+                candidates = list(base_path.glob(glob_pattern))
+        out: List[Path] = []
+        for p in candidates:
+            if not p.is_file():
+                continue
+            ext = p.suffix.lower()
+            if allowed_exts and ext not in allowed_exts:
+                continue
+            out.append(p.resolve())
+        out.sort(key=lambda x: x.as_posix().lower())
+        return out
+
+    async def create_upload_task(self, files: List[Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        self._ensure_ready()
+        if not files:
+            raise ValueError("至少需要上传一个文件")
+
+        params = self._normalize_params(payload)
+        max_files = self._max_files_per_task()
+        if len(files) > max_files:
+            raise ValueError(f"单任务文件数超过上限: {max_files}")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="upload",
+                params=params,
+                status="queued",
+                current_step="queued",
+            )
+            task_dir = self._temp_root / task.task_id
+            task_dir.mkdir(parents=True, exist_ok=True)
+
+            max_size = self._max_file_size_bytes()
+            for idx, uploaded in enumerate(files):
+                name = _safe_filename(getattr(uploaded, "filename", f"file_{idx}.txt"))
+                ext = Path(name).suffix.lower()
+                if ext not in {".txt", ".md", ".json"}:
+                    raise ValueError(f"不支持的文件类型: {name}")
+                content = await uploaded.read()
+                if len(content) > max_size:
+                    raise ValueError(f"文件超过大小限制: {name}")
+                file_id = uuid.uuid4().hex
+                temp_path = task_dir / f"{file_id}_{name}"
+                temp_path.write_bytes(content)
+                file_mode = "json" if ext == ".json" else params["input_mode"]
+                task.files.append(
+                    ImportFileRecord(
+                        file_id=file_id,
+                        name=name,
+                        source_kind="upload",
+                        input_mode=file_mode,
+                        temp_path=str(temp_path),
+                    )
+                )
+
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_paste_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        self._ensure_ready()
+
+        params = self._normalize_params(payload)
+        params["task_kind"] = "paste"
+        content = str(payload.get("content", "") or "")
+        if not content.strip():
+            raise ValueError("content 不能为空")
+        if len(content) > self._max_paste_chars():
+            raise ValueError(f"粘贴内容超过限制: {self._max_paste_chars()} 字符")
+
+        name = _safe_filename(payload.get("name") or f"paste_{int(_now())}.txt")
+        if params["input_mode"] == "json" and Path(name).suffix.lower() != ".json":
+            name = f"{Path(name).stem}.json"
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="paste",
+                params=params,
+                status="queued",
+                current_step="queued",
+            )
+            task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=name,
+                    source_kind="paste",
+                    input_mode=params["input_mode"],
+                    inline_content=content,
+                )
+            )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_raw_scan_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        self._ensure_ready()
+        params = self._normalize_raw_scan_params(payload)
+        source_path = self.resolve_path_alias(
+            params["alias"],
+            params["relative_path"],
+            must_exist=True,
+        )
+        files = self._scan_files(
+            source_path,
+            recursive=bool(params["recursive"]),
+            glob_pattern=str(params["glob"] or "*"),
+            allowed_exts={".txt", ".md", ".json"},
+        )
+        if not files:
+            raise ValueError("未找到可导入文件")
+        if len(files) > self._max_files_per_task():
+            raise ValueError(f"单任务文件数超过上限: {self._max_files_per_task()}")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="raw_scan",
+                params=params,
+                status="queued",
+                current_step="queued",
+            )
+            for path in files:
+                mode = "json" if path.suffix.lower() == ".json" else params["input_mode"]
+                task.files.append(
+                    ImportFileRecord(
+                        file_id=uuid.uuid4().hex,
+                        name=path.name,
+                        source_kind="raw_scan",
+                        input_mode=mode,
+                        source_path=str(path),
+                    )
+                )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_lpmm_openie_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        self._ensure_ready()
+        params = self._normalize_lpmm_openie_params(payload)
+        source_path = self.resolve_path_alias(
+            params["alias"],
+            params["relative_path"],
+            must_exist=True,
+        )
+        files: List[Path] = []
+        if source_path.is_file():
+            files = [source_path]
+        else:
+            files = self._scan_files(
+                source_path,
+                recursive=True,
+                glob_pattern="*-openie.json",
+                allowed_exts={".json"},
+            )
+            if not files and params.get("include_all_json"):
+                files = self._scan_files(
+                    source_path,
+                    recursive=True,
+                    glob_pattern="*.json",
+                    allowed_exts={".json"},
+                )
+        if not files:
+            raise ValueError("未找到 LPMM OpenIE JSON 文件")
+        if len(files) > self._max_files_per_task():
+            raise ValueError(f"单任务文件数超过上限: {self._max_files_per_task()}")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="lpmm_openie",
+                params=params,
+                status="queued",
+                current_step="queued",
+                schema_detected="lpmm_openie",
+            )
+            for path in files:
+                task.files.append(
+                    ImportFileRecord(
+                        file_id=uuid.uuid4().hex,
+                        name=path.name,
+                        source_kind="lpmm_openie",
+                        input_mode="json",
+                        source_path=str(path),
+                    )
+                )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_temporal_backfill_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        params = self._normalize_temporal_backfill_params(payload)
+        target_path = self.resolve_path_alias(
+            params["alias"],
+            params["relative_path"],
+            must_exist=True,
+        )
+        if not target_path.is_dir():
+            raise ValueError("temporal_backfill 目标路径必须为目录")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="temporal_backfill",
+                params=params,
+                status="queued",
+                current_step="queued",
+            )
+            task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=f"temporal_backfill_{int(_now())}",
+                    source_kind="temporal_backfill",
+                    input_mode="json",
+                    source_path=str(target_path),
+                )
+            )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_lpmm_convert_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        params = self._normalize_lpmm_convert_params(payload)
+        source_path = self.resolve_path_alias(
+            params["alias"],
+            params["relative_path"],
+            must_exist=True,
+        )
+        if not source_path.is_dir():
+            raise ValueError("lpmm_convert 输入路径必须为目录")
+        target_path = self.resolve_path_alias(
+            params["target_alias"],
+            params["target_relative_path"],
+            must_exist=False,
+        )
+        target_path.mkdir(parents=True, exist_ok=True)
+        if not target_path.is_dir():
+            raise ValueError("lpmm_convert 目标路径必须为目录")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="lpmm_convert",
+                params={**params, "source_path": str(source_path), "target_path": str(target_path)},
+                status="queued",
+                current_step="queued",
+            )
+            task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=f"lpmm_convert_{int(_now())}",
+                    source_kind="lpmm_convert",
+                    input_mode="json",
+                    source_path=str(source_path),
+                )
+            )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def create_maibot_migration_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_enabled():
+            raise ValueError("导入功能已禁用")
+        self._ensure_ready()
+
+        params = self._normalize_migration_params(payload)
+        script_path = self._resolve_migration_script()
+        if not script_path.exists():
+            raise ValueError(f"迁移脚本不存在: {script_path}")
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+
+            task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source="maibot_migration",
+                params=params,
+                status="queued",
+                current_step="queued",
+            )
+            task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=f"maibot_migration_{int(_now())}",
+                    source_kind="maibot_migration",
+                    input_mode="text",
+                    inline_content=json.dumps(params, ensure_ascii=False),
+                )
+            )
+            self._tasks[task.task_id] = task
+            self._task_order.appendleft(task.task_id)
+            self._queue.append(task.task_id)
+
+        await self._ensure_worker()
+        return task.to_summary()
+
+    async def list_tasks(self, limit: int = 50) -> List[Dict[str, Any]]:
+        async with self._lock:
+            task_ids = list(self._task_order)[: max(1, int(limit))]
+            return [self._tasks[task_id].to_summary() for task_id in task_ids if task_id in self._tasks]
+
+    async def get_task(self, task_id: str, include_chunks: bool = False) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return None
+            return task.to_detail(include_chunks=include_chunks)
+
+    async def get_chunks(self, task_id: str, file_id: str, offset: int = 0, limit: int = 50) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return None
+            file_obj = self._find_file(task, file_id)
+            if not file_obj:
+                return None
+            start = max(0, int(offset))
+            size = max(1, min(500, int(limit)))
+            items = file_obj.chunks[start : start + size]
+            return {
+                "task_id": task_id,
+                "file_id": file_id,
+                "offset": start,
+                "limit": size,
+                "total": len(file_obj.chunks),
+                "items": [x.to_dict() for x in items],
+            }
+
+    async def cancel_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return None
+            if task.status == "queued":
+                self._mark_task_cancelled_locked(task, "任务已取消")
+                self._queue = deque([x for x in self._queue if x != task_id])
+            elif task.status in {"preparing", "running"}:
+                task.status = "cancel_requested"
+                task.current_step = "cancel_requested"
+                task.updated_at = _now()
+            return task.to_summary()
+
+    def _build_retry_plan(self, task: ImportTaskRecord) -> Dict[str, Any]:
+        chunk_retry_candidates: List[Tuple[ImportFileRecord, List[int]]] = []
+        file_fallback_candidates: List[ImportFileRecord] = []
+        skipped: List[Dict[str, str]] = []
+
+        for file_obj in task.files:
+            if file_obj.status == "cancelled":
+                continue
+
+            failed_chunks = [c for c in file_obj.chunks if c.status == "failed"]
+            has_file_level_failure = file_obj.status == "failed" and not failed_chunks
+            if has_file_level_failure:
+                file_fallback_candidates.append(file_obj)
+                continue
+
+            if not failed_chunks:
+                continue
+
+            retry_indexes: List[int] = []
+            has_non_retryable = False
+            for chunk in failed_chunks:
+                failed_at = str(chunk.failed_at or "").strip().lower()
+                retryable = bool(chunk.retryable) or (
+                    file_obj.input_mode == "text" and failed_at == "extracting"
+                )
+                if retryable:
+                    try:
+                        retry_indexes.append(int(chunk.index))
+                    except Exception:
+                        has_non_retryable = True
+                else:
+                    has_non_retryable = True
+
+            if has_non_retryable:
+                file_fallback_candidates.append(file_obj)
+                continue
+
+            retry_indexes = sorted(set(retry_indexes))
+            if retry_indexes:
+                chunk_retry_candidates.append((file_obj, retry_indexes))
+            else:
+                skipped.append(
+                    {
+                        "file_name": file_obj.name,
+                        "source_kind": file_obj.source_kind,
+                        "reason": "no_retryable_failed_chunks",
+                    }
+                )
+
+        unique_fallback: List[ImportFileRecord] = []
+        fallback_seen = set()
+        for file_obj in file_fallback_candidates:
+            if file_obj.file_id in fallback_seen:
+                continue
+            fallback_seen.add(file_obj.file_id)
+            unique_fallback.append(file_obj)
+
+        return {
+            "chunk_retry_candidates": chunk_retry_candidates,
+            "file_fallback_candidates": unique_fallback,
+            "skipped": skipped,
+        }
+
+    def _clone_failed_file_for_retry(
+        self,
+        retry_task: ImportTaskRecord,
+        failed_file: ImportFileRecord,
+        task_dir: Path,
+        *,
+        retry_mode: str,
+        retry_chunk_indexes: Optional[List[int]] = None,
+    ) -> Tuple[bool, str]:
+        source_kind = str(failed_file.source_kind or "").strip().lower()
+        retry_chunk_indexes = list(retry_chunk_indexes or [])
+
+        if source_kind == "upload":
+            candidate_paths: List[Path] = []
+            if failed_file.temp_path:
+                candidate_paths.append(Path(failed_file.temp_path))
+            if failed_file.source_path:
+                candidate_paths.append(Path(failed_file.source_path))
+            src_path = next((p for p in candidate_paths if p.exists() and p.is_file()), None)
+            if src_path is None:
+                return False, "upload_source_missing"
+            data = src_path.read_bytes()
+            file_id = uuid.uuid4().hex
+            name = _safe_filename(failed_file.name)
+            dst = task_dir / f"{file_id}_{name}"
+            dst.write_bytes(data)
+            retry_task.files.append(
+                ImportFileRecord(
+                    file_id=file_id,
+                    name=name,
+                    source_kind="upload",
+                    input_mode=failed_file.input_mode,
+                    temp_path=str(dst),
+                    retry_mode=retry_mode,
+                    retry_chunk_indexes=retry_chunk_indexes,
+                )
+            )
+            return True, ""
+
+        if source_kind == "paste":
+            if failed_file.inline_content is None:
+                return False, "paste_content_missing"
+            retry_task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=_safe_filename(failed_file.name),
+                    source_kind="paste",
+                    input_mode=failed_file.input_mode,
+                    inline_content=failed_file.inline_content,
+                    retry_mode=retry_mode,
+                    retry_chunk_indexes=retry_chunk_indexes,
+                )
+            )
+            return True, ""
+
+        if source_kind == "maibot_migration":
+            retry_task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=_safe_filename(failed_file.name),
+                    source_kind="maibot_migration",
+                    input_mode="text",
+                    inline_content=failed_file.inline_content,
+                    retry_mode="file_fallback",
+                    retry_chunk_indexes=[],
+                )
+            )
+            return True, ""
+
+        if source_kind in {"raw_scan", "lpmm_openie", "lpmm_convert", "temporal_backfill"}:
+            retry_task.files.append(
+                ImportFileRecord(
+                    file_id=uuid.uuid4().hex,
+                    name=_safe_filename(failed_file.name),
+                    source_kind=source_kind,
+                    input_mode=failed_file.input_mode,
+                    source_path=failed_file.source_path,
+                    inline_content=failed_file.inline_content,
+                    retry_mode=retry_mode,
+                    retry_chunk_indexes=retry_chunk_indexes,
+                )
+            )
+            return True, ""
+
+        return False, f"unsupported_source_kind:{source_kind or 'unknown'}"
+
+    async def retry_failed(self, task_id: str, overrides: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return None
+            retry_plan = self._build_retry_plan(task)
+            chunk_retry_candidates = list(retry_plan["chunk_retry_candidates"])
+            file_fallback_candidates = list(retry_plan["file_fallback_candidates"])
+            skipped_candidates = list(retry_plan["skipped"])
+            if not chunk_retry_candidates and not file_fallback_candidates:
+                raise ValueError("当前任务没有可重试失败项")
+            base_params = dict(task.params)
+            task_kind = str(task.params.get("task_kind") or "").strip().lower()
+
+        if overrides:
+            base_params.update(overrides)
+        params = self._normalize_by_task_kind(task_kind, base_params)
+        params["retry_parent_task_id"] = task_id
+        params["retry_strategy"] = "chunk_first_auto_file_fallback"
+
+        async with self._lock:
+            if self._pending_task_count() >= self._queue_limit():
+                raise ValueError("任务队列已满，请稍后重试")
+            retry_task = ImportTaskRecord(
+                task_id=uuid.uuid4().hex,
+                source=task.source,
+                params=params,
+                status="queued",
+                current_step="queued",
+                schema_detected=task.schema_detected,
+                retry_parent_task_id=task_id,
+            )
+
+            task_dir = self._temp_root / retry_task.task_id
+            task_dir.mkdir(parents=True, exist_ok=True)
+
+            retry_summary = {
+                "chunk_retry_files": 0,
+                "chunk_retry_chunks": 0,
+                "file_fallback_files": 0,
+                "skipped_files": 0,
+                "parent_task_id": task_id,
+            }
+            skipped_details = list(skipped_candidates)
+
+            for file_obj, chunk_indexes in chunk_retry_candidates:
+                ok, reason = self._clone_failed_file_for_retry(
+                    retry_task,
+                    file_obj,
+                    task_dir,
+                    retry_mode="chunk",
+                    retry_chunk_indexes=chunk_indexes,
+                )
+                if ok:
+                    retry_summary["chunk_retry_files"] += 1
+                    retry_summary["chunk_retry_chunks"] += len(chunk_indexes)
+                else:
+                    skipped_details.append(
+                        {
+                            "file_name": file_obj.name,
+                            "source_kind": file_obj.source_kind,
+                            "reason": reason,
+                        }
+                    )
+
+            for file_obj in file_fallback_candidates:
+                ok, reason = self._clone_failed_file_for_retry(
+                    retry_task,
+                    file_obj,
+                    task_dir,
+                    retry_mode="file_fallback",
+                    retry_chunk_indexes=[],
+                )
+                if ok:
+                    retry_summary["file_fallback_files"] += 1
+                else:
+                    skipped_details.append(
+                        {
+                            "file_name": file_obj.name,
+                            "source_kind": file_obj.source_kind,
+                            "reason": reason,
+                        }
+                    )
+
+            retry_summary["skipped_files"] = len(skipped_details)
+            if skipped_details:
+                retry_summary["skipped_details"] = skipped_details
+            retry_task.retry_summary = retry_summary
+
+            if not retry_task.files:
+                raise ValueError("无可执行的重试输入：失败项均无法构建重试任务")
+
+            self._tasks[retry_task.task_id] = retry_task
+            self._task_order.appendleft(retry_task.task_id)
+            self._queue.append(retry_task.task_id)
+            logger.info(
+                "重试任务已创建 "
+                f"parent={task_id} retry={retry_task.task_id} "
+                f"chunk_files={retry_summary['chunk_retry_files']} "
+                f"chunk_chunks={retry_summary['chunk_retry_chunks']} "
+                f"file_fallback={retry_summary['file_fallback_files']} "
+                f"skipped={retry_summary['skipped_files']}"
+            )
+
+        await self._ensure_worker()
+        return retry_task.to_summary()
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            self._stopping = True
+            for task in self._tasks.values():
+                if task.status in {"queued", "preparing", "running", "cancel_requested"}:
+                    self._mark_task_cancelled_locked(task, "服务关闭")
+            self._queue.clear()
+            worker = self._worker_task
+            self._worker_task = None
+
+        if worker:
+            worker.cancel()
+            try:
+                await worker
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+
+        self._cleanup_temp_root()
+
+    def _cleanup_temp_root(self) -> None:
+        try:
+            if not self._temp_root.exists():
+                return
+            for child in self._temp_root.rglob("*"):
+                if child.is_file():
+                    child.unlink(missing_ok=True)
+            for child in sorted(self._temp_root.rglob("*"), reverse=True):
+                if child.is_dir():
+                    child.rmdir()
+            self._temp_root.rmdir()
+        except Exception as e:
+            logger.warning(f"清理临时导入目录失败: {e}")
+
+    async def _worker_loop(self) -> None:
+        logger.info("Web 导入任务 worker 已启动")
+        while True:
+            if self._stopping:
+                break
+
+            task_id: Optional[str] = None
+            async with self._lock:
+                while self._queue:
+                    candidate = self._queue.popleft()
+                    t = self._tasks.get(candidate)
+                    if not t:
+                        continue
+                    if t.status == "cancelled":
+                        continue
+                    task_id = candidate
+                    self._active_task_id = candidate
+                    break
+
+            if not task_id:
+                await asyncio.sleep(0.2)
+                continue
+
+            try:
+                await self._run_task(task_id)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"导入任务执行失败 task={task_id}: {e}", exc_info=True)
+                async with self._lock:
+                    task = self._tasks.get(task_id)
+                    if task and task.status not in {"cancelled", "completed", "completed_with_errors"}:
+                        task.status = "failed"
+                        task.current_step = "failed"
+                        task.error = str(e)
+                        task.finished_at = _now()
+                        task.updated_at = _now()
+            finally:
+                should_cleanup = await self._should_cleanup_task_temp(task_id)
+                async with self._lock:
+                    if self._active_task_id == task_id:
+                        self._active_task_id = None
+                if should_cleanup:
+                    await self._cleanup_task_temp_files(task_id)
+
+        logger.info("Web 导入任务 worker 已停止")
+
+    async def _cleanup_task_temp_files(self, task_id: str) -> None:
+        task_dir = self._temp_root / task_id
+        if not task_dir.exists():
+            return
+        try:
+            for child in task_dir.rglob("*"):
+                if child.is_file():
+                    child.unlink(missing_ok=True)
+            for child in sorted(task_dir.rglob("*"), reverse=True):
+                if child.is_dir():
+                    child.rmdir()
+            task_dir.rmdir()
+        except Exception as e:
+            logger.warning(f"清理任务临时文件失败 task={task_id}: {e}")
+
+    def _task_report_path(self, task_id: str) -> Path:
+        self._reports_root.mkdir(parents=True, exist_ok=True)
+        return self._reports_root / f"{task_id}_summary.json"
+
+    def _write_task_report(self, task: ImportTaskRecord) -> None:
+        path = self._task_report_path(task.task_id)
+        payload = task.to_detail(include_chunks=False)
+        payload["generated_at"] = _now()
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        task.artifact_paths["summary"] = str(path)
+
+    async def _run_task(self, task_id: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            task.status = "preparing"
+            task.current_step = "preparing"
+            task.started_at = _now()
+            task.updated_at = _now()
+            if task.params.get("clear_manifest"):
+                self._clear_manifest()
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            if task.status == "cancel_requested":
+                task.status = "cancelled"
+                task.current_step = "cancelled"
+                task.finished_at = _now()
+                task.updated_at = _now()
+                return
+            task.status = "running"
+            task.current_step = "running"
+            task.updated_at = _now()
+
+        task_kind = str(task.params.get("task_kind") or task.source).strip().lower()
+        if task_kind == "maibot_migration":
+            if not task.files:
+                raise RuntimeError("迁移任务缺少文件记录")
+            await self._process_maibot_migration(task_id, task.files[0])
+        elif task_kind == "temporal_backfill":
+            if not task.files:
+                raise RuntimeError("回填任务缺少文件记录")
+            await self._process_temporal_backfill(task_id, task.files[0])
+        elif task_kind == "lpmm_convert":
+            if not task.files:
+                raise RuntimeError("转换任务缺少文件记录")
+            await self._process_lpmm_convert(task_id, task.files[0])
+        else:
+            file_semaphore = asyncio.Semaphore(task.params["file_concurrency"])
+            chunk_semaphore = asyncio.Semaphore(task.params["chunk_concurrency"])
+            jobs = [
+                asyncio.create_task(self._process_file(task_id, f, file_semaphore, chunk_semaphore))
+                for f in task.files
+            ]
+            await asyncio.gather(*jobs, return_exceptions=True)
+
+        write_changed_payload: Optional[Dict[str, Any]] = None
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            self._recompute_task_progress(task)
+            has_failed = any(
+                (f.status == "failed")
+                or (f.failed_chunks > 0)
+                or bool(str(f.error or "").strip())
+                for f in task.files
+            )
+            has_cancelled = any(f.status == "cancelled" for f in task.files)
+            has_completed = any(f.status == "completed" for f in task.files)
+
+            # 统一按文件真实终态收敛任务状态，避免出现“任务已取消但文件已完成”的矛盾结果。
+            if has_failed and not has_cancelled:
+                task.status = "completed_with_errors"
+                task.current_step = "completed_with_errors"
+            elif has_cancelled and not has_completed:
+                task.status = "cancelled"
+                task.current_step = "cancelled"
+            elif has_cancelled and has_completed:
+                task.status = "cancelled"
+                task.current_step = "cancelled"
+            else:
+                task.status = "completed"
+                task.current_step = "completed"
+            task.finished_at = _now()
+            task.updated_at = _now()
+            try:
+                self._write_task_report(task)
+            except Exception as report_err:
+                logger.warning(f"写入任务报告失败 task={task_id}: {report_err}")
+            task_kind = str(task.params.get("task_kind") or task.source).strip().lower()
+            write_task_kinds = {"upload", "paste", "raw_scan", "lpmm_openie", "maibot_migration", "lpmm_convert"}
+            has_written_chunks = (task.done_chunks > 0) or any(f.done_chunks > 0 for f in task.files)
+            if task_kind in write_task_kinds and has_written_chunks:
+                write_changed_payload = {
+                    "task_id": task.task_id,
+                    "task_kind": task_kind,
+                    "status": task.status,
+                    "done_chunks": task.done_chunks,
+                    "finished_at": task.finished_at,
+                }
+
+        if write_changed_payload:
+            await self._notify_write_changed(write_changed_payload)
+
+    def _build_maibot_migration_command(self, params: Dict[str, Any]) -> List[str]:
+        script_path = self._resolve_migration_script()
+        if not script_path.exists():
+            raise RuntimeError(f"迁移脚本不存在: {script_path}")
+
+        cmd = [
+            sys.executable,
+            str(script_path),
+            "--source-db",
+            str(params["source_db"]),
+            "--target-data-dir",
+            str(params["target_data_dir"]),
+            "--read-batch-size",
+            str(params["read_batch_size"]),
+            "--commit-window-rows",
+            str(params["commit_window_rows"]),
+            "--embed-batch-size",
+            str(params["embed_batch_size"]),
+            "--entity-embed-batch-size",
+            str(params["entity_embed_batch_size"]),
+            "--max-errors",
+            str(params["max_errors"]),
+            "--log-every",
+            str(params["log_every"]),
+            "--preview-limit",
+            str(params["preview_limit"]),
+            "--yes",
+        ]
+
+        if params.get("embed_workers") is not None:
+            cmd.extend(["--embed-workers", str(params["embed_workers"])])
+        if params.get("start_id") is not None:
+            cmd.extend(["--start-id", str(params["start_id"])])
+        if params.get("end_id") is not None:
+            cmd.extend(["--end-id", str(params["end_id"])])
+        if params.get("time_from"):
+            cmd.extend(["--time-from", str(params["time_from"])])
+        if params.get("time_to"):
+            cmd.extend(["--time-to", str(params["time_to"])])
+
+        for sid in params.get("stream_ids") or []:
+            cmd.extend(["--stream-id", str(sid)])
+        for gid in params.get("group_ids") or []:
+            cmd.extend(["--group-id", str(gid)])
+        for uid in params.get("user_ids") or []:
+            cmd.extend(["--user-id", str(uid)])
+
+        if params.get("reset_state"):
+            cmd.append("--reset-state")
+        if params.get("no_resume"):
+            cmd.append("--no-resume")
+        if params.get("dry_run"):
+            cmd.append("--dry-run")
+        if params.get("verify_only"):
+            cmd.append("--verify-only")
+
+        return cmd
+
+    async def _ensure_maibot_migration_chunk(
+        self,
+        task_id: str,
+        file_id: str,
+        *,
+        chunk_type: str = "maibot_migration",
+        preview: str = "MaiBot chat_history 迁移任务",
+    ) -> str:
+        chunk_id = f"{file_id}_{chunk_type}"
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return chunk_id
+            f = self._find_file(task, file_id)
+            if not f:
+                return chunk_id
+            if not f.chunks:
+                f.chunks = [
+                    ImportChunkRecord(
+                        chunk_id=chunk_id,
+                        index=0,
+                        chunk_type=chunk_type,
+                        status="queued",
+                        step="queued",
+                        progress=0.0,
+                        content_preview=preview,
+                    )
+                ]
+                f.total_chunks = 1
+                f.done_chunks = 0
+                f.failed_chunks = 0
+                f.cancelled_chunks = 0
+                f.progress = 0.0
+                f.updated_at = _now()
+                self._recompute_task_progress(task)
+            else:
+                chunk_id = f.chunks[0].chunk_id
+        return chunk_id
+
+    async def _refresh_maibot_progress_from_state(
+        self,
+        task_id: str,
+        file_id: str,
+        chunk_id: str,
+        state_path: Path,
+    ) -> None:
+        if not state_path.exists():
+            return
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+
+        stats = payload.get("stats", {}) if isinstance(payload, dict) else {}
+        if not isinstance(stats, dict):
+            stats = {}
+
+        total = max(0, _coerce_int(stats.get("source_matched_total", 0), 0))
+        scanned = max(0, _coerce_int(stats.get("scanned_rows", 0), 0))
+        bad = max(0, _coerce_int(stats.get("bad_rows", 0), 0))
+        done = max(0, scanned - bad)
+        migrated = max(0, _coerce_int(stats.get("migrated_rows", 0), 0))
+        last_id = max(0, _coerce_int(stats.get("last_committed_id", 0), 0))
+
+        if total <= 0:
+            total = max(1, scanned)
+
+        progress = max(0.0, min(1.0, float(scanned) / float(total))) if total > 0 else 0.0
+        preview = f"scanned={scanned}/{total}, migrated={migrated}, bad={bad}, last_id={last_id}"
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            c = self._find_chunk(f, chunk_id)
+            if c:
+                if c.status not in {"completed", "failed", "cancelled"}:
+                    c.status = "writing"
+                    c.step = "migrating"
+                c.progress = progress
+                c.content_preview = preview
+                c.updated_at = _now()
+            f.total_chunks = total
+            f.done_chunks = done
+            f.failed_chunks = bad
+            f.cancelled_chunks = 0
+            f.progress = progress
+            if f.status not in {"failed", "cancelled"}:
+                f.status = "writing"
+                f.current_step = "migrating"
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _terminate_process(self, process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        try:
+            process.terminate()
+            await asyncio.wait_for(process.wait(), timeout=5.0)
+        except Exception:
+            try:
+                process.kill()
+                await asyncio.wait_for(process.wait(), timeout=3.0)
+            except Exception:
+                pass
+
+    async def _reload_stores_after_external_migration(self) -> None:
+        async with self._storage_lock:
+            try:
+                if self.plugin.vector_store and self.plugin.vector_store.has_data():
+                    self.plugin.vector_store.load()
+            except Exception as e:
+                logger.warning(f"迁移后重载 VectorStore 失败: {e}")
+            try:
+                if self.plugin.graph_store and self.plugin.graph_store.has_data():
+                    self.plugin.graph_store.load()
+            except Exception as e:
+                logger.warning(f"迁移后重载 GraphStore 失败: {e}")
+
+    async def _process_maibot_migration(self, task_id: str, file_record: ImportFileRecord) -> None:
+        await self._set_file_strategy(task_id, file_record.file_id, "maibot_migration")
+        await self._set_file_state(task_id, file_record.file_id, "preparing", "preparing")
+        chunk_id = await self._ensure_maibot_migration_chunk(
+            task_id,
+            file_record.file_id,
+            chunk_type="maibot_migration",
+            preview="MaiBot chat_history 迁移任务",
+        )
+        await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "migrating", 0.0)
+
+        task = self._tasks.get(task_id)
+        if not task:
+            await self._set_file_failed(task_id, file_record.file_id, "任务不存在")
+            return
+        params = dict(task.params)
+
+        command = self._build_maibot_migration_command(params)
+        project_root = Path(__file__).resolve().parents[4]
+        state_path = Path(params["target_data_dir"]) / "migration_state" / "chat_history_resume.json"
+        report_path = Path(params["target_data_dir"]) / "migration_state" / "chat_history_report.json"
+
+        logger.info(f"开始执行 MaiBot 迁移任务: {' '.join(command)}")
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(project_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdout_lines: List[str] = []
+        stderr_lines: List[str] = []
+
+        async def _drain(stream: Optional[asyncio.StreamReader], target: List[str]) -> None:
+            if stream is None:
+                return
+            while True:
+                line = await stream.readline()
+                if not line:
+                    break
+                text = line.decode("utf-8", errors="replace").strip()
+                if not text:
+                    continue
+                target.append(text)
+                if len(target) > 120:
+                    del target[:-120]
+
+        drain_tasks = [
+            asyncio.create_task(_drain(process.stdout, stdout_lines)),
+            asyncio.create_task(_drain(process.stderr, stderr_lines)),
+        ]
+
+        cancelled = False
+        return_code: Optional[int] = None
+        try:
+            while True:
+                if await self._is_cancel_requested(task_id):
+                    cancelled = True
+                    await self._terminate_process(process)
+                    break
+
+                await self._refresh_maibot_progress_from_state(task_id, file_record.file_id, chunk_id, state_path)
+                try:
+                    return_code = await asyncio.wait_for(process.wait(), timeout=1.0)
+                    break
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            await asyncio.gather(*drain_tasks, return_exceptions=True)
+
+        if cancelled:
+            await self._set_chunk_cancelled(task_id, file_record.file_id, chunk_id, "任务已取消")
+            await self._set_file_cancelled(task_id, file_record.file_id, "任务已取消")
+            return
+
+        await self._refresh_maibot_progress_from_state(task_id, file_record.file_id, chunk_id, state_path)
+
+        report: Dict[str, Any] = {}
+        if report_path.exists():
+            try:
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+            except Exception:
+                report = {}
+
+        stats = report.get("stats", {}) if isinstance(report, dict) else {}
+        if not isinstance(stats, dict):
+            stats = {}
+        bad_rows = max(0, _coerce_int(stats.get("bad_rows", 0), 0))
+
+        if return_code in {0, 2}:
+            await self._set_file_state(task_id, file_record.file_id, "saving", "saving")
+            await self._reload_stores_after_external_migration()
+
+            async with self._lock:
+                task2 = self._tasks.get(task_id)
+                if not task2:
+                    return
+                f = self._find_file(task2, file_record.file_id)
+                if not f:
+                    return
+                c = self._find_chunk(f, chunk_id)
+                if c and c.status not in {"cancelled", "failed"}:
+                    c.status = "completed"
+                    c.step = "completed"
+                    c.progress = 1.0
+                    c.updated_at = _now()
+                if f.total_chunks <= 0:
+                    f.total_chunks = 1
+                if f.done_chunks + f.failed_chunks <= 0:
+                    f.done_chunks = f.total_chunks - bad_rows
+                    f.failed_chunks = bad_rows
+                f.done_chunks = max(0, min(f.done_chunks, f.total_chunks))
+                f.failed_chunks = max(0, min(f.failed_chunks, f.total_chunks))
+                f.cancelled_chunks = 0
+                f.progress = 1.0
+                f.status = "completed"
+                f.current_step = "completed"
+                if bad_rows > 0 and not f.error:
+                    f.error = f"迁移完成，但存在坏行: {bad_rows}"
+                f.updated_at = _now()
+                self._recompute_task_progress(task2)
+            return
+
+        fail_reason = ""
+        if isinstance(report, dict):
+            fail_reason = str(report.get("fail_reason") or "").strip()
+        tail = (stderr_lines[-1] if stderr_lines else "") or (stdout_lines[-1] if stdout_lines else "")
+        detail = fail_reason or tail or f"迁移进程退出码: {return_code}"
+        await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, detail)
+        await self._set_file_failed(task_id, file_record.file_id, detail)
+
+    def _resolve_convert_script(self) -> Path:
+        return Path(__file__).resolve().parents[2] / "scripts" / "convert_lpmm.py"
+
+    def _cleanup_old_backups(self) -> None:
+        keep = max(0, self._cfg_int("web.import.convert.keep_backup_count", 3))
+        backup_root = self._resolve_backup_root()
+        if not backup_root.exists() or keep <= 0:
+            return
+        dirs = [p for p in backup_root.iterdir() if p.is_dir() and p.name.startswith("lpmm_convert_")]
+        dirs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for old in dirs[keep:]:
+            try:
+                shutil.rmtree(old, ignore_errors=True)
+            except Exception:
+                pass
+
+    def _verify_convert_output(self, output_dir: Path) -> Dict[str, Any]:
+        vectors = output_dir / "vectors"
+        graph = output_dir / "graph"
+        metadata = output_dir / "metadata"
+        checks = {
+            "vectors_exists": vectors.exists(),
+            "graph_exists": graph.exists(),
+            "metadata_exists": metadata.exists(),
+            "vectors_nonempty": vectors.exists() and any(vectors.iterdir()),
+            "graph_nonempty": graph.exists() and any(graph.iterdir()),
+            "metadata_nonempty": metadata.exists() and any(metadata.iterdir()),
+        }
+        checks["ok"] = checks["vectors_exists"] and checks["graph_exists"] and checks["metadata_exists"]
+        return checks
+
+    async def _preflight_convert_runtime(self) -> Tuple[bool, str]:
+        """使用当前服务解释器做 convert 依赖预检，避免子进程报错信息不透明。"""
+        probe_code = (
+            "import importlib\n"
+            "mods=['networkx','scipy','pyarrow']\n"
+            "failed=[]\n"
+            "for m in mods:\n"
+            "    try:\n"
+            "        importlib.import_module(m)\n"
+            "    except Exception as e:\n"
+            "        failed.append(f'{m}:{e.__class__.__name__}:{e}')\n"
+            "print('OK' if not failed else ';'.join(failed))\n"
+        )
+        try:
+            probe = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                probe_code,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(probe.communicate(), timeout=20.0)
+        except Exception as e:
+            return False, f"依赖预检执行失败: {e}"
+
+        out = (stdout or b"").decode("utf-8", errors="replace").strip()
+        err = (stderr or b"").decode("utf-8", errors="replace").strip()
+        if probe.returncode != 0:
+            detail = err or out or f"return_code={probe.returncode}"
+            return False, f"依赖预检失败 (python={sys.executable}): {detail}"
+        if out != "OK":
+            return False, f"依赖预检失败 (python={sys.executable}): {out}"
+        return True, ""
+
+    async def _process_lpmm_convert(self, task_id: str, file_record: ImportFileRecord) -> None:
+        await self._set_file_strategy(task_id, file_record.file_id, "lpmm_convert")
+        await self._set_file_state(task_id, file_record.file_id, "preparing", "preflight")
+        chunk_id = await self._ensure_maibot_migration_chunk(
+            task_id,
+            file_record.file_id,
+            chunk_type="lpmm_convert",
+            preview="LPMM 二进制转换任务",
+        )
+        await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "converting", 0.05)
+
+        task = self._tasks.get(task_id)
+        if not task:
+            await self._set_file_failed(task_id, file_record.file_id, "任务不存在")
+            return
+        params = dict(task.params)
+        source_dir = Path(params.get("source_path") or "")
+        target_dir = Path(params.get("target_path") or "")
+        if not source_dir.exists() or not source_dir.is_dir():
+            await self._set_file_failed(task_id, file_record.file_id, f"输入目录无效: {source_dir}")
+            return
+        if not target_dir.exists() or not target_dir.is_dir():
+            await self._set_file_failed(task_id, file_record.file_id, f"目标目录无效: {target_dir}")
+            return
+
+        script_path = self._resolve_convert_script()
+        if not script_path.exists():
+            await self._set_file_failed(task_id, file_record.file_id, f"转换脚本不存在: {script_path}")
+            return
+
+        runtime_ok, runtime_detail = await self._preflight_convert_runtime()
+        if not runtime_ok:
+            await self._set_file_failed(task_id, file_record.file_id, runtime_detail)
+            await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, runtime_detail)
+            return
+
+        required_inputs = ["paragraph.parquet", "entity.parquet"]
+        if not any((source_dir / name).exists() for name in required_inputs):
+            await self._set_file_failed(
+                task_id,
+                file_record.file_id,
+                f"输入目录缺少必要文件，至少需要其一: {', '.join(required_inputs)}",
+            )
+            return
+
+        staging_root = self._resolve_staging_root()
+        staging_root.mkdir(parents=True, exist_ok=True)
+        staging_dir = staging_root / f"lpmm_convert_{task_id}"
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        staging_dir.mkdir(parents=True, exist_ok=True)
+
+        # 简单空间预检：至少保留 512MB
+        usage = shutil.disk_usage(str(target_dir))
+        if usage.free < 512 * 1024 * 1024:
+            await self._set_file_failed(task_id, file_record.file_id, "磁盘剩余空间不足（<512MB）")
+            return
+
+        cmd = [
+            sys.executable,
+            str(script_path),
+            "--input",
+            str(source_dir),
+            "--output",
+            str(staging_dir),
+            "--dim",
+            str(params.get("dimension", 384)),
+            "--batch-size",
+            str(params.get("batch_size", 1024)),
+        ]
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(self._resolve_repo_root()),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_lines: List[str] = []
+        stderr_lines: List[str] = []
+
+        async def _drain(stream: Optional[asyncio.StreamReader], target: List[str]) -> None:
+            if stream is None:
+                return
+            while True:
+                line = await stream.readline()
+                if not line:
+                    break
+                text = line.decode("utf-8", errors="replace").strip()
+                if text:
+                    target.append(text)
+                    if len(target) > 120:
+                        del target[:-120]
+
+        drain_tasks = [
+            asyncio.create_task(_drain(process.stdout, stdout_lines)),
+            asyncio.create_task(_drain(process.stderr, stderr_lines)),
+        ]
+
+        cancelled = False
+        return_code: Optional[int] = None
+        try:
+            while True:
+                if await self._is_cancel_requested(task_id):
+                    cancelled = True
+                    await self._terminate_process(process)
+                    break
+                try:
+                    return_code = await asyncio.wait_for(process.wait(), timeout=1.0)
+                    break
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            await asyncio.gather(*drain_tasks, return_exceptions=True)
+
+        if cancelled:
+            await self._set_chunk_cancelled(task_id, file_record.file_id, chunk_id, "任务已取消")
+            await self._set_file_cancelled(task_id, file_record.file_id, "任务已取消")
+            return
+        if return_code != 0:
+            detail = (stderr_lines[-1] if stderr_lines else "") or (stdout_lines[-1] if stdout_lines else "")
+            await self._set_file_failed(task_id, file_record.file_id, detail or f"转换失败，退出码: {return_code}")
+            await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, detail or f"退出码: {return_code}")
+            return
+
+        await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "verifying", 0.65)
+        verify = self._verify_convert_output(staging_dir)
+        async with self._lock:
+            t = self._tasks.get(task_id)
+            if t:
+                t.artifact_paths["staging_dir"] = str(staging_dir)
+                t.artifact_paths["verify"] = json.dumps(verify, ensure_ascii=False)
+        if not verify.get("ok"):
+            await self._set_file_failed(task_id, file_record.file_id, f"校验失败: {verify}")
+            await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, f"校验失败: {verify}")
+            return
+
+        enable_switch = _coerce_bool(self._cfg("web.import.convert.enable_staging_switch", True), True)
+        if not enable_switch:
+            await self._set_file_failed(task_id, file_record.file_id, "未启用 staging 切换")
+            await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, "未启用 staging 切换")
+            return
+
+        await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "switching", 0.85)
+        backup_root = self._resolve_backup_root()
+        backup_root.mkdir(parents=True, exist_ok=True)
+        backup_dir = backup_root / f"lpmm_convert_{task_id}_{int(_now())}"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        switched = False
+        rollback_info: Dict[str, Any] = {"attempted": True, "restored": False, "error": ""}
+        moved_items: List[Tuple[Path, Path]] = []
+        try:
+            for name in ("vectors", "graph", "metadata"):
+                src_current = target_dir / name
+                src_new = staging_dir / name
+                if not src_new.exists():
+                    raise RuntimeError(f"staging 缺少目录: {src_new}")
+                if src_current.exists():
+                    dst_backup = backup_dir / name
+                    shutil.move(str(src_current), str(dst_backup))
+                    moved_items.append((dst_backup, src_current))
+                shutil.move(str(src_new), str(src_current))
+            switched = True
+        except Exception as switch_err:
+            rollback_info["error"] = str(switch_err)
+            # 尝试回滚
+            for src_backup, dst_original in moved_items:
+                if src_backup.exists() and not dst_original.exists():
+                    try:
+                        shutil.move(str(src_backup), str(dst_original))
+                    except Exception:
+                        pass
+            rollback_info["restored"] = True
+            async with self._lock:
+                t = self._tasks.get(task_id)
+                if t:
+                    t.rollback_info = rollback_info
+            await self._set_file_failed(task_id, file_record.file_id, f"切换失败并回滚: {switch_err}")
+            await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, f"switch failed: {switch_err}")
+            return
+
+        if switched:
+            async with self._lock:
+                t = self._tasks.get(task_id)
+                if t:
+                    t.rollback_info = rollback_info
+                    t.artifact_paths["backup_dir"] = str(backup_dir)
+            self._cleanup_old_backups()
+            try:
+                sync_init = getattr(self.plugin, "_sync_initialize", None)
+                if callable(sync_init):
+                    sync_init()
+                else:
+                    await self._reload_stores_after_external_migration()
+            except Exception as reload_err:
+                logger.warning(f"转换后重载存储失败: {reload_err}")
+
+        await self._set_chunk_completed(task_id, file_record.file_id, chunk_id)
+        async with self._lock:
+            t = self._tasks.get(task_id)
+            if not t:
+                return
+            f = self._find_file(t, file_record.file_id)
+            if not f:
+                return
+            f.total_chunks = 1
+            f.done_chunks = 1
+            f.failed_chunks = 0
+            f.cancelled_chunks = 0
+            f.progress = 1.0
+            f.status = "completed"
+            f.current_step = "completed"
+            f.updated_at = _now()
+            self._recompute_task_progress(t)
+
+    async def _process_temporal_backfill(self, task_id: str, file_record: ImportFileRecord) -> None:
+        await self._set_file_strategy(task_id, file_record.file_id, "temporal_backfill")
+        await self._set_file_state(task_id, file_record.file_id, "preparing", "backfilling")
+        chunk_id = await self._ensure_maibot_migration_chunk(
+            task_id,
+            file_record.file_id,
+            chunk_type="temporal_backfill",
+            preview="时序字段回填任务",
+        )
+        await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "backfilling", 0.2)
+
+        task = self._tasks.get(task_id)
+        if not task:
+            await self._set_file_failed(task_id, file_record.file_id, "任务不存在")
+            return
+        params = dict(task.params)
+        target_dir = Path(file_record.source_path or "")
+        metadata_dir = target_dir / "metadata"
+        if not metadata_dir.exists():
+            await self._set_file_failed(task_id, file_record.file_id, f"metadata 目录不存在: {metadata_dir}")
+            return
+
+        dry_run = bool(params.get("dry_run"))
+        no_created_fallback = bool(params.get("no_created_fallback"))
+        limit = max(1, _coerce_int(params.get("limit"), 100000))
+
+        store = MetadataStore(data_dir=metadata_dir)
+        updated = 0
+        candidates = 0
+        try:
+            store.connect()
+            cursor = store._conn.cursor()
+            cursor.execute(
+                """
+                SELECT hash, created_at
+                FROM paragraphs
+                WHERE (event_time IS NULL AND event_time_start IS NULL AND event_time_end IS NULL)
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+            rows = cursor.fetchall()
+            candidates = len(rows)
+            if not dry_run and not no_created_fallback:
+                for row in rows:
+                    created_at = row["created_at"]
+                    if created_at is None:
+                        continue
+                    cursor.execute(
+                        """
+                        UPDATE paragraphs
+                        SET event_time = ?, time_granularity = ?, time_confidence = ?, updated_at = ?
+                        WHERE hash = ?
+                        """,
+                        (float(created_at), "day", 0.2, float(created_at), row["hash"]),
+                    )
+                    if cursor.rowcount > 0:
+                        updated += 1
+                store._conn.commit()
+        finally:
+            try:
+                store.close()
+            except Exception:
+                pass
+
+        async with self._lock:
+            t = self._tasks.get(task_id)
+            if t:
+                t.artifact_paths["temporal_backfill"] = json.dumps(
+                    {
+                        "target_dir": str(target_dir),
+                        "dry_run": dry_run,
+                        "no_created_fallback": no_created_fallback,
+                        "limit": limit,
+                        "candidates": candidates,
+                        "updated": updated,
+                    },
+                    ensure_ascii=False,
+                )
+        await self._set_chunk_completed(task_id, file_record.file_id, chunk_id)
+        async with self._lock:
+            t = self._tasks.get(task_id)
+            if not t:
+                return
+            f = self._find_file(t, file_record.file_id)
+            if not f:
+                return
+            f.total_chunks = 1
+            f.done_chunks = 1
+            f.failed_chunks = 0
+            f.cancelled_chunks = 0
+            f.progress = 1.0
+            f.status = "completed"
+            f.current_step = "completed"
+            f.updated_at = _now()
+            self._recompute_task_progress(t)
+
+    async def _process_file(
+        self,
+        task_id: str,
+        file_record: ImportFileRecord,
+        file_semaphore: asyncio.Semaphore,
+        chunk_semaphore: asyncio.Semaphore,
+    ) -> None:
+        async with file_semaphore:
+            await self._set_file_state(task_id, file_record.file_id, "preparing", "preparing")
+            if await self._is_cancel_requested(task_id):
+                await self._set_file_cancelled(task_id, file_record.file_id, "任务已取消")
+                return
+
+            try:
+                content = await self._read_file_content(file_record)
+                content_hash = hashlib.md5(content.encode("utf-8", errors="ignore")).hexdigest()
+                file_record.content_hash = content_hash
+                task = self._tasks.get(task_id)
+                if task:
+                    dedupe_policy = str(task.params.get("dedupe_policy") or "none")
+                    force = bool(task.params.get("force"))
+                    if dedupe_policy != "none" and not force:
+                        async with self._lock:
+                            if self._is_manifest_hit(file_record, content_hash, dedupe_policy):
+                                task2 = self._tasks.get(task_id)
+                                if task2:
+                                    f = self._find_file(task2, file_record.file_id)
+                                    if f:
+                                        f.status = "completed"
+                                        f.current_step = "skipped"
+                                        f.progress = 1.0
+                                        f.total_chunks = 0
+                                        f.done_chunks = 0
+                                        f.failed_chunks = 0
+                                        f.cancelled_chunks = 0
+                                        f.detected_strategy_type = "skipped"
+                                        f.error = ""
+                                        f.updated_at = _now()
+                                        self._recompute_task_progress(task2)
+                                return
+                if file_record.input_mode == "json":
+                    await self._process_json_file(task_id, file_record, content, chunk_semaphore)
+                else:
+                    await self._process_text_file(task_id, file_record, content, chunk_semaphore)
+                task3 = self._tasks.get(task_id)
+                if task3:
+                    dedupe_policy = str(task3.params.get("dedupe_policy") or "none")
+                    f3 = self._find_file(task3, file_record.file_id)
+                    if dedupe_policy != "none" and f3 and f3.status == "completed":
+                        async with self._lock:
+                            self._record_manifest_import(file_record, content_hash, dedupe_policy, task_id)
+            except Exception as e:
+                await self._set_file_failed(task_id, file_record.file_id, str(e))
+
+    async def _read_file_content(self, file_record: ImportFileRecord) -> str:
+        if file_record.inline_content is not None:
+            return file_record.inline_content
+        if file_record.source_path and Path(file_record.source_path).exists():
+            data = Path(file_record.source_path).read_bytes()
+            try:
+                return data.decode("utf-8")
+            except UnicodeDecodeError:
+                return data.decode("utf-8", errors="replace")
+        if file_record.temp_path and Path(file_record.temp_path).exists():
+            data = Path(file_record.temp_path).read_bytes()
+            try:
+                return data.decode("utf-8")
+            except UnicodeDecodeError:
+                return data.decode("utf-8", errors="replace")
+        raise RuntimeError("读取文件失败：输入内容缺失")
+
+    async def _process_text_file(
+        self,
+        task_id: str,
+        file_record: ImportFileRecord,
+        content: str,
+        chunk_semaphore: asyncio.Semaphore,
+    ) -> None:
+        task = self._tasks[task_id]
+        async with self._lock:
+            t = self._tasks.get(task_id)
+            if t and not t.schema_detected:
+                t.schema_detected = "plain_text"
+        strategy = self._determine_strategy(
+            file_record.name,
+            content,
+            task.params["strategy_override"],
+            chat_log=bool(task.params.get("chat_log")),
+        )
+        await self._set_file_strategy(task_id, file_record.file_id, strategy)
+        await self._set_file_state(task_id, file_record.file_id, "splitting", "splitting")
+
+        chunks = strategy.split(content)
+        selected_chunks = list(chunks)
+        if file_record.retry_mode == "chunk":
+            retry_index_set = set()
+            for idx in file_record.retry_chunk_indexes:
+                try:
+                    retry_index_set.add(int(idx))
+                except Exception:
+                    continue
+            selected_chunks = [chunk for chunk in chunks if int(chunk.chunk.index) in retry_index_set]
+            if not selected_chunks:
+                raise RuntimeError("失败分块重试索引无效，未匹配到可执行分块")
+            logger.info(
+                "重试任务按失败分块执行 file=%s selected=%s total=%s",
+                file_record.name,
+                len(selected_chunks),
+                len(chunks),
+            )
+
+        await self._register_chunks(task_id, file_record.file_id, selected_chunks)
+
+        await self._set_file_state(task_id, file_record.file_id, "extracting", "extracting")
+        model_cfg = None
+        if task.params["llm_enabled"]:
+            model_cfg = await self._select_model()
+
+        jobs = []
+        for chunk in selected_chunks:
+            jobs.append(
+                asyncio.create_task(
+                    self._process_text_chunk(
+                        task_id=task_id,
+                        file_record=file_record,
+                        chunk=chunk,
+                        strategy=strategy,
+                        llm_enabled=task.params["llm_enabled"],
+                        model_cfg=model_cfg,
+                        chunk_semaphore=chunk_semaphore,
+                        chat_log=bool(task.params.get("chat_log")),
+                        chat_reference_time=str(task.params.get("chat_reference_time") or "").strip() or None,
+                    )
+                )
+            )
+        await asyncio.gather(*jobs, return_exceptions=True)
+
+        if await self._is_cancel_requested(task_id):
+            await self._set_file_cancelled(task_id, file_record.file_id, "任务已取消")
+            return
+
+        await self._set_file_state(task_id, file_record.file_id, "saving", "saving")
+        async with self._storage_lock:
+            self.plugin.vector_store.save()
+            self.plugin.graph_store.save()
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_record.file_id)
+            if not f:
+                return
+            if f.failed_chunks > 0:
+                f.status = "failed"
+                f.current_step = "failed"
+                if not f.error:
+                    f.error = f"存在失败分块: {f.failed_chunks}"
+            elif task.status == "cancel_requested":
+                f.status = "cancelled"
+                f.current_step = "cancelled"
+            else:
+                f.status = "completed"
+                f.current_step = "completed"
+                f.progress = 1.0
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+    async def _process_text_chunk(
+        self,
+        task_id: str,
+        file_record: ImportFileRecord,
+        chunk: ProcessedChunk,
+        strategy: Any,
+        llm_enabled: bool,
+        model_cfg: Any,
+        chunk_semaphore: asyncio.Semaphore,
+        chat_log: bool = False,
+        chat_reference_time: Optional[str] = None,
+    ) -> None:
+        async with chunk_semaphore:
+            chunk_id = chunk.chunk.chunk_id
+            if await self._is_cancel_requested(task_id):
+                await self._set_chunk_cancelled(task_id, file_record.file_id, chunk_id, "任务已取消")
+                return
+
+            await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "extracting", "extracting", 0.25)
+
+            processed = chunk
+            rescue_strategy = self._chunk_rescue(chunk, file_record.name)
+            current_strategy = strategy
+            if rescue_strategy:
+                chunk.type = StrategyKnowledgeType.QUOTE
+                chunk.flags.verbatim = True
+                chunk.flags.requires_llm = False
+                current_strategy = rescue_strategy
+            try:
+                if llm_enabled and chunk.flags.requires_llm:
+                    processed = await current_strategy.extract(
+                        chunk,
+                        lambda prompt: self._llm_call(prompt, model_cfg),
+                    )
+                elif chunk.type == StrategyKnowledgeType.QUOTE:
+                    processed = await current_strategy.extract(chunk)
+            except Exception as e:
+                await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, f"抽取失败: {e}")
+                return
+
+            if await self._is_cancel_requested(task_id):
+                await self._set_chunk_cancelled(task_id, file_record.file_id, chunk_id, "任务已取消")
+                return
+
+            await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "writing", 0.7)
+            try:
+                time_meta = None
+                if chat_log and llm_enabled and model_cfg is not None:
+                    time_meta = await self._extract_chat_time_meta_with_llm(
+                        processed.chunk.text,
+                        model_cfg,
+                        reference_time=chat_reference_time,
+                    )
+                async with self._storage_lock:
+                    await self._persist_processed_chunk(file_record, processed, time_meta=time_meta)
+                await self._set_chunk_completed(task_id, file_record.file_id, chunk_id)
+            except Exception as e:
+                await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, f"写入失败: {e}")
+
+    async def _process_json_file(
+        self,
+        task_id: str,
+        file_record: ImportFileRecord,
+        content: str,
+        chunk_semaphore: asyncio.Semaphore,
+    ) -> None:
+        await self._set_file_strategy(task_id, file_record.file_id, "json")
+        await self._set_file_state(task_id, file_record.file_id, "splitting", "splitting")
+
+        try:
+            data = json.loads(content)
+        except Exception as e:
+            raise RuntimeError(f"JSON 解析失败: {e}")
+
+        schema = self._detect_json_schema(data)
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task:
+                task.schema_detected = schema
+                task.updated_at = _now()
+        units = self._build_json_units(data, file_record.file_id, file_record.name, schema)
+        await self._register_json_units(task_id, file_record.file_id, units)
+
+        await self._set_file_state(task_id, file_record.file_id, "extracting", "extracting")
+        jobs = [
+            asyncio.create_task(self._process_json_unit(task_id, file_record, unit, chunk_semaphore))
+            for unit in units
+        ]
+        await asyncio.gather(*jobs, return_exceptions=True)
+
+        if await self._is_cancel_requested(task_id):
+            await self._set_file_cancelled(task_id, file_record.file_id, "任务已取消")
+            return
+
+        await self._set_file_state(task_id, file_record.file_id, "saving", "saving")
+        async with self._storage_lock:
+            self.plugin.vector_store.save()
+            self.plugin.graph_store.save()
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_record.file_id)
+            if not f:
+                return
+            if f.failed_chunks > 0:
+                f.status = "failed"
+                f.current_step = "failed"
+                if not f.error:
+                    f.error = f"存在失败分块: {f.failed_chunks}"
+            elif task.status == "cancel_requested":
+                f.status = "cancelled"
+                f.current_step = "cancelled"
+            else:
+                f.status = "completed"
+                f.current_step = "completed"
+                f.progress = 1.0
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    def _detect_json_schema(self, data: Any) -> str:
+        if isinstance(data, dict) and isinstance(data.get("docs"), list):
+            return "lpmm_openie"
+        if isinstance(data, dict) and isinstance(data.get("paragraphs"), list):
+            paragraphs = data.get("paragraphs", [])
+            for p in paragraphs:
+                if isinstance(p, dict) and any(
+                    key in p for key in ("entities", "relations", "time_meta", "source", "type")
+                ):
+                    return "script_json"
+            return "web_json"
+        raise RuntimeError("不支持的 JSON 格式：需要 paragraphs 或 docs")
+
+    def _build_json_units(self, data: Any, file_id: str, filename: str, schema: str) -> List[Dict[str, Any]]:
+        units: List[Dict[str, Any]] = []
+        paragraphs: List[Any] = []
+        entities: List[Any] = []
+        relations: List[Any] = []
+
+        if schema in {"web_json", "script_json"}:
+            paragraphs = data.get("paragraphs", [])
+            entities = data.get("entities", [])
+            relations = data.get("relations", [])
+        elif schema == "lpmm_openie":
+            docs = data.get("docs", [])
+            for d in docs:
+                if not isinstance(d, dict):
+                    continue
+                content = str(d.get("passage", "") or "").strip()
+                if not content:
+                    continue
+                triples = d.get("extracted_triples", []) or []
+                rels = []
+                for t in triples:
+                    if isinstance(t, list) and len(t) == 3:
+                        rels.append(
+                            {
+                                "subject": str(t[0]),
+                                "predicate": str(t[1]),
+                                "object": str(t[2]),
+                            }
+                        )
+                para_item = {
+                    "content": content,
+                    "source": f"lpmm_openie:{filename}",
+                    "entities": d.get("extracted_entities", []) or [],
+                    "relations": rels,
+                    "knowledge_type": "factual",
+                }
+                paragraphs.append(para_item)
+
+        for idx, p in enumerate(paragraphs):
+            if isinstance(p, str):
+                units.append(
+                    {
+                        "chunk_id": f"{file_id}_json_{len(units)}",
+                        "kind": "paragraph",
+                        "content": p,
+                        "time_meta": None,
+                        "knowledge_type": detect_knowledge_type(p).value,
+                        "chunk_type": detect_knowledge_type(p).value,
+                        "source": f"web_import:{filename}",
+                        "entities": [],
+                        "relations": [],
+                        "preview": p[:120],
+                    }
+                )
+            elif isinstance(p, dict) and "content" in p:
+                content = str(p.get("content", ""))
+                raw_time_meta = {
+                    "event_time": p.get("event_time"),
+                    "event_time_start": p.get("event_time_start"),
+                    "event_time_end": p.get("event_time_end"),
+                    "time_range": p.get("time_range"),
+                    "time_granularity": p.get("time_granularity"),
+                    "time_confidence": p.get("time_confidence"),
+                }
+                if isinstance(p.get("time_meta"), dict):
+                    raw_time_meta.update(p.get("time_meta") or {})
+                k_type = str(p.get("knowledge_type") or p.get("type") or detect_knowledge_type(content).value)
+                local_relations: List[Dict[str, str]] = []
+                for rel in p.get("relations", []) or []:
+                    if not isinstance(rel, dict):
+                        continue
+                    s = str(rel.get("subject", "")).strip()
+                    pred = str(rel.get("predicate", "")).strip()
+                    o = str(rel.get("object", "")).strip()
+                    if s and pred and o:
+                        local_relations.append({"subject": s, "predicate": pred, "object": o})
+                units.append(
+                    {
+                        "chunk_id": f"{file_id}_json_{len(units)}",
+                        "kind": "paragraph",
+                        "content": content,
+                        "time_meta": normalize_time_meta(raw_time_meta),
+                        "knowledge_type": k_type,
+                        "chunk_type": k_type,
+                        "source": str(p.get("source") or f"web_import:{filename}"),
+                        "entities": [str(x) for x in (p.get("entities") or []) if str(x).strip()],
+                        "relations": local_relations,
+                        "preview": content[:120],
+                    }
+                )
+
+        for e in entities:
+            name = str(e or "").strip()
+            if name:
+                units.append(
+                    {
+                        "chunk_id": f"{file_id}_json_{len(units)}",
+                        "kind": "entity",
+                        "name": name,
+                        "chunk_type": "entity",
+                        "preview": name[:120],
+                    }
+                )
+
+        for r in relations:
+            if not isinstance(r, dict):
+                continue
+            s = str(r.get("subject", "")).strip()
+            p = str(r.get("predicate", "")).strip()
+            o = str(r.get("object", "")).strip()
+            if s and p and o:
+                units.append(
+                    {
+                        "chunk_id": f"{file_id}_json_{len(units)}",
+                        "kind": "relation",
+                        "subject": s,
+                        "predicate": p,
+                        "object": o,
+                        "chunk_type": "relation",
+                        "preview": f"{s} {p} {o}"[:120],
+                    }
+                )
+        return units
+
+    async def _register_json_units(self, task_id: str, file_id: str, units: List[Dict[str, Any]]) -> None:
+        records = [
+            ImportChunkRecord(
+                chunk_id=u["chunk_id"],
+                index=i,
+                chunk_type=u.get("chunk_type", "json"),
+                status="queued",
+                step="queued",
+                progress=0.0,
+                content_preview=str(u.get("preview", "")),
+            )
+            for i, u in enumerate(units)
+        ]
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.chunks = records
+            f.total_chunks = len(records)
+            f.done_chunks = 0
+            f.failed_chunks = 0
+            f.cancelled_chunks = 0
+            f.progress = 0.0 if records else 1.0
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _process_json_unit(
+        self,
+        task_id: str,
+        file_record: ImportFileRecord,
+        unit: Dict[str, Any],
+        chunk_semaphore: asyncio.Semaphore,
+    ) -> None:
+        chunk_id = unit["chunk_id"]
+        async with chunk_semaphore:
+            if await self._is_cancel_requested(task_id):
+                await self._set_chunk_cancelled(task_id, file_record.file_id, chunk_id, "任务已取消")
+                return
+
+            await self._set_chunk_state(task_id, file_record.file_id, chunk_id, "writing", "writing", 0.7)
+            try:
+                async with self._storage_lock:
+                    kind = unit["kind"]
+                    if kind == "paragraph":
+                        content = str(unit.get("content", ""))
+                        k_type = str(unit.get("knowledge_type") or detect_knowledge_type(content).value)
+                        source = str(unit.get("source") or f"web_import:{file_record.name}")
+                        para_hash = self.plugin.metadata_store.add_paragraph(
+                            content=content,
+                            source=source,
+                            knowledge_type=k_type,
+                            time_meta=unit.get("time_meta"),
+                        )
+                        emb = await self.plugin.embedding_manager.encode(content)
+                        try:
+                            self.plugin.vector_store.add(emb.reshape(1, -1), [para_hash])
+                        except ValueError:
+                            pass
+                        for name in unit.get("entities", []) or []:
+                            n = str(name or "").strip()
+                            if n:
+                                await self._add_entity_with_vector(n, source_paragraph=para_hash)
+                        for rel in unit.get("relations", []) or []:
+                            if not isinstance(rel, dict):
+                                continue
+                            s = str(rel.get("subject", "")).strip()
+                            p = str(rel.get("predicate", "")).strip()
+                            o = str(rel.get("object", "")).strip()
+                            if s and p and o:
+                                await self._add_relation(s, p, o, source_paragraph=para_hash)
+                    elif kind == "entity":
+                        await self._add_entity_with_vector(unit["name"])
+                    elif kind == "relation":
+                        await self._add_relation(unit["subject"], unit["predicate"], unit["object"])
+                    else:
+                        raise RuntimeError(f"未知 JSON 导入单元类型: {kind}")
+                await self._set_chunk_completed(task_id, file_record.file_id, chunk_id)
+            except Exception as e:
+                await self._set_chunk_failed(task_id, file_record.file_id, chunk_id, f"写入失败: {e}")
+
+    def _source_label(self, file_record: ImportFileRecord) -> str:
+        if file_record.source_path:
+            return f"{file_record.source_kind}:{file_record.source_path}"
+        return f"web_import:{file_record.name}"
+
+    async def _persist_processed_chunk(
+        self,
+        file_record: ImportFileRecord,
+        processed: ProcessedChunk,
+        *,
+        time_meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        content = processed.chunk.text
+        para_hash = self.plugin.metadata_store.add_paragraph(
+            content=content,
+            source=self._source_label(file_record),
+            knowledge_type=_storage_type_from_strategy(processed.type),
+            time_meta=time_meta,
+        )
+
+        emb = await self.plugin.embedding_manager.encode(content)
+        try:
+            self.plugin.vector_store.add(emb.reshape(1, -1), [para_hash])
+        except ValueError:
+            pass
+
+        data = processed.data or {}
+        entities: List[str] = []
+        relations: List[Tuple[str, str, str]] = []
+
+        for triple in data.get("triples", []):
+            s = str(triple.get("subject", "")).strip()
+            p = str(triple.get("predicate", "")).strip()
+            o = str(triple.get("object", "")).strip()
+            if s and p and o:
+                relations.append((s, p, o))
+                entities.extend([s, o])
+
+        for rel in data.get("relations", []):
+            s = str(rel.get("subject", "")).strip()
+            p = str(rel.get("predicate", "")).strip()
+            o = str(rel.get("object", "")).strip()
+            if s and p and o:
+                relations.append((s, p, o))
+                entities.extend([s, o])
+
+        for k in ("entities", "events", "verbatim_entities"):
+            for e in data.get(k, []):
+                name = str(e or "").strip()
+                if name:
+                    entities.append(name)
+
+        uniq_entities = list({x.strip().lower(): x.strip() for x in entities if str(x).strip()}.values())
+        for name in uniq_entities:
+            await self._add_entity_with_vector(name, source_paragraph=para_hash)
+
+        for s, p, o in relations:
+            await self._add_relation(s, p, o, source_paragraph=para_hash)
+
+    async def _add_entity_with_vector(self, name: str, source_paragraph: str = "") -> str:
+        hash_value = self.plugin.metadata_store.add_entity(name=name, source_paragraph=source_paragraph)
+        self.plugin.graph_store.add_nodes([name])
+        if hash_value not in self.plugin.vector_store:
+            emb = await self.plugin.embedding_manager.encode(name)
+            try:
+                self.plugin.vector_store.add(emb.reshape(1, -1), [hash_value])
+            except ValueError:
+                pass
+        return hash_value
+
+    async def _add_relation(self, subject: str, predicate: str, obj: str, source_paragraph: str = "") -> str:
+        await self._add_entity_with_vector(subject, source_paragraph=source_paragraph)
+        await self._add_entity_with_vector(obj, source_paragraph=source_paragraph)
+        rel_hash = self.plugin.metadata_store.add_relation(
+            subject=subject,
+            predicate=predicate,
+            obj=obj,
+            source_paragraph=source_paragraph,
+            confidence=1.0,
+        )
+        self.plugin.graph_store.add_edges([(subject, obj)], relation_hashes=[rel_hash])
+        return rel_hash
+    async def _select_model(self) -> Any:
+        models = llm_api.get_available_models()
+        if not models:
+            raise RuntimeError("没有可用 LLM 模型")
+
+        config_model = str(self._cfg("advanced.extraction_model", "auto") or "auto").strip()
+        if config_model.lower() != "auto" and config_model in models:
+            return models[config_model]
+
+        for task_name in [
+            "lpmm_entity_extract",
+            "lpmm_rdf_build",
+            "embedding",
+            "replyer",
+            "utils",
+            "planner",
+            "tool_use",
+        ]:
+            if task_name in models:
+                return models[task_name]
+
+        return models[next(iter(models))]
+
+    async def _llm_call(self, prompt: str, model_config: Any) -> Dict[str, Any]:
+        cfg = self._llm_retry_config()
+        retries = int(cfg["retries"])
+        last_error: Optional[Exception] = None
+        for attempt in range(retries + 1):
+            try:
+                success, response, _, _ = await llm_api.generate_with_model(
+                    prompt=prompt,
+                    model_config=model_config,
+                    request_type="A_Memorix.WebImport",
+                )
+                if not success or not response:
+                    raise RuntimeError("LLM 生成失败")
+
+                txt = str(response or "").strip()
+                if "```" in txt:
+                    txt = txt.split("```json")[-1].split("```")[0].strip()
+                    if txt.startswith("json"):
+                        txt = txt[4:].strip()
+
+                try:
+                    return json.loads(txt)
+                except Exception:
+                    s = txt.find("{")
+                    e = txt.rfind("}")
+                    if s >= 0 and e > s:
+                        return json.loads(txt[s : e + 1])
+                    raise
+            except Exception as err:
+                last_error = err
+                if attempt >= retries:
+                    break
+                delay = min(cfg["max_wait"], cfg["min_wait"] * (cfg["multiplier"] ** attempt))
+                await asyncio.sleep(max(0.0, float(delay)))
+        raise RuntimeError(f"LLM 抽取失败: {last_error}")
+
+    def _parse_reference_time(self, value: Optional[str]) -> datetime:
+        if not value:
+            return datetime.now()
+        text = str(value).strip()
+        formats = [
+            "%Y/%m/%d %H:%M:%S",
+            "%Y/%m/%d %H:%M",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+            "%Y/%m/%d",
+            "%Y-%m-%d",
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(text, fmt)
+            except ValueError:
+                continue
+        return datetime.now()
+
+    async def _extract_chat_time_meta_with_llm(
+        self,
+        text: str,
+        model_config: Any,
+        *,
+        reference_time: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if not str(text or "").strip():
+            return None
+        ref_dt = self._parse_reference_time(reference_time)
+        reference_now = ref_dt.strftime("%Y/%m/%d %H:%M")
+        prompt = f"""You are a time extraction engine for chat logs.
+Extract temporal information from the following chat paragraph.
+
+Rules:
+1. Use semantic understanding, not regex matching.
+2. Convert relative expressions to absolute local datetime using reference_now.
+3. If a time span exists, return event_time_start/event_time_end.
+4. If only one point in time exists, return event_time.
+5. If no reliable time info exists, keep all event_time fields null.
+6. Return JSON only.
+
+reference_now: {reference_now}
+text:
+{text}
+
+JSON schema:
+{{
+  "event_time": null,
+  "event_time_start": null,
+  "event_time_end": null,
+  "time_range": null,
+  "time_granularity": null,
+  "time_confidence": 0.0
+}}
+"""
+        try:
+            result = await self._llm_call(prompt, model_config)
+        except Exception as e:
+            logger.warning(f"chat_log 时间语义抽取失败: {e}")
+            return None
+
+        raw_time_meta = {
+            "event_time": result.get("event_time"),
+            "event_time_start": result.get("event_time_start"),
+            "event_time_end": result.get("event_time_end"),
+            "time_range": result.get("time_range"),
+            "time_granularity": result.get("time_granularity"),
+            "time_confidence": result.get("time_confidence"),
+        }
+        try:
+            normalized = normalize_time_meta(raw_time_meta)
+        except Exception:
+            return None
+        has_effective = any(k in normalized for k in ("event_time", "event_time_start", "event_time_end"))
+        if not has_effective:
+            return None
+        return normalized
+
+    def _chunk_rescue(self, chunk: ProcessedChunk, filename: str) -> Optional[Any]:
+        if chunk.type == StrategyKnowledgeType.QUOTE:
+            return None
+        text = chunk.chunk.text
+        lines = [l for l in text.split("\n") if l.strip()]
+        if not lines:
+            return None
+        avg_len = sum(len(l) for l in lines) / len(lines)
+        if avg_len < 25 and len(lines) > 4:
+            return QuoteStrategy(filename)
+        return None
+
+    def _determine_strategy(self, filename: str, content: str, override: str, *, chat_log: bool = False) -> Any:
+        if chat_log:
+            return NarrativeStrategy(filename)
+        if override == "narrative":
+            return NarrativeStrategy(filename)
+        if override == "factual":
+            return FactualStrategy(filename)
+        if override == "quote":
+            return QuoteStrategy(filename)
+
+        head = content[:500]
+        lines = head.split("\n")
+        avg_len = sum(len(l) for l in lines if l.strip()) / (len(lines) + 1e-9)
+        if avg_len < 20 and len(lines) > 5:
+            return QuoteStrategy(filename)
+        if "Chapter" in head or "CHAPTER" in head or "###" in head:
+            return NarrativeStrategy(filename)
+
+        return NarrativeStrategy(filename)
+
+    async def _set_file_strategy(self, task_id: str, file_id: str, strategy: Any) -> None:
+        if isinstance(strategy, str):
+            strategy_type = strategy
+        elif isinstance(strategy, NarrativeStrategy):
+            strategy_type = "narrative"
+        elif isinstance(strategy, FactualStrategy):
+            strategy_type = "factual"
+        elif isinstance(strategy, QuoteStrategy):
+            strategy_type = "quote"
+        else:
+            strategy_type = "unknown"
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.detected_strategy_type = strategy_type
+            f.updated_at = _now()
+            task.updated_at = _now()
+
+    async def _register_chunks(self, task_id: str, file_id: str, chunks: List[ProcessedChunk]) -> None:
+        records = [
+            ImportChunkRecord(
+                chunk_id=chunk.chunk.chunk_id,
+                index=index,
+                chunk_type=chunk.type.value,
+                status="queued",
+                step="queued",
+                progress=0.0,
+                content_preview=str(chunk.chunk.text or "")[:120],
+            )
+            for index, chunk in enumerate(chunks)
+        ]
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.chunks = records
+            f.total_chunks = len(records)
+            f.done_chunks = 0
+            f.failed_chunks = 0
+            f.cancelled_chunks = 0
+            f.progress = 0.0 if records else 1.0
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _set_file_state(self, task_id: str, file_id: str, status: str, step: str) -> None:
+        if status not in FILE_STATUS:
+            return
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.status = status
+            f.current_step = step
+            f.updated_at = _now()
+            task.updated_at = _now()
+            if step in {"preparing", "splitting", "extracting", "writing", "saving"} and task.status in {"queued", "preparing"}:
+                task.status = "running"
+                task.current_step = "running"
+
+    async def _set_file_failed(self, task_id: str, file_id: str, error: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.status = "failed"
+            f.current_step = "failed"
+            f.error = str(error)
+            f.updated_at = _now()
+            task.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _set_file_cancelled(self, task_id: str, file_id: str, reason: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            f.status = "cancelled"
+            f.current_step = "cancelled"
+            f.error = reason
+            additional_cancelled = 0
+            for chunk in f.chunks:
+                if chunk.status in {"completed", "failed", "cancelled"}:
+                    continue
+                chunk.status = "cancelled"
+                chunk.step = "cancelled"
+                chunk.retryable = False
+                chunk.error = reason
+                chunk.progress = 1.0
+                chunk.updated_at = _now()
+                additional_cancelled += 1
+            if additional_cancelled > 0:
+                f.cancelled_chunks += additional_cancelled
+                f.progress = self._compute_ratio(
+                    f.done_chunks + f.failed_chunks + f.cancelled_chunks, f.total_chunks
+                )
+            f.updated_at = _now()
+            task.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _set_chunk_state(
+        self,
+        task_id: str,
+        file_id: str,
+        chunk_id: str,
+        status: str,
+        step: str,
+        progress: float,
+    ) -> None:
+        if status not in CHUNK_STATUS:
+            return
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            c = self._find_chunk(f, chunk_id)
+            if not c:
+                return
+            c.status = status
+            c.step = step
+            if status in {"queued", "extracting", "writing"}:
+                c.error = ""
+                c.failed_at = ""
+                c.retryable = False
+            c.progress = max(0.0, min(1.0, float(progress)))
+            c.updated_at = _now()
+            if f.status not in {"failed", "cancelled"}:
+                f.status = "extracting" if status == "extracting" else "writing"
+                f.current_step = step
+            f.updated_at = _now()
+            task.updated_at = _now()
+
+    async def _set_chunk_completed(self, task_id: str, file_id: str, chunk_id: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            c = self._find_chunk(f, chunk_id)
+            if not c or c.status == "completed":
+                return
+            c.status = "completed"
+            c.step = "completed"
+            c.failed_at = ""
+            c.retryable = False
+            c.progress = 1.0
+            c.updated_at = _now()
+            f.done_chunks += 1
+            f.progress = self._compute_ratio(f.done_chunks + f.failed_chunks + f.cancelled_chunks, f.total_chunks)
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _set_chunk_failed(self, task_id: str, file_id: str, chunk_id: str, error: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            c = self._find_chunk(f, chunk_id)
+            if not c or c.status == "failed":
+                return
+            failed_stage = str(c.step or "").strip().lower()
+            if failed_stage in {"", "queued", "failed", "completed", "cancelled"}:
+                failed_stage = str(f.current_step or "").strip().lower()
+            if failed_stage in {"", "queued", "failed", "completed", "cancelled"}:
+                failed_stage = "unknown"
+            c.status = "failed"
+            c.step = "failed"
+            c.failed_at = failed_stage
+            c.retryable = bool(f.input_mode == "text" and failed_stage == "extracting")
+            c.error = str(error)
+            c.progress = 1.0
+            c.updated_at = _now()
+            f.failed_chunks += 1
+            f.progress = self._compute_ratio(f.done_chunks + f.failed_chunks + f.cancelled_chunks, f.total_chunks)
+            if not f.error:
+                f.error = str(error)
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _set_chunk_cancelled(self, task_id: str, file_id: str, chunk_id: str, reason: str) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            f = self._find_file(task, file_id)
+            if not f:
+                return
+            c = self._find_chunk(f, chunk_id)
+            if not c or c.status == "cancelled":
+                return
+            c.status = "cancelled"
+            c.step = "cancelled"
+            c.retryable = False
+            c.error = reason
+            c.progress = 1.0
+            c.updated_at = _now()
+            f.cancelled_chunks += 1
+            f.progress = self._compute_ratio(f.done_chunks + f.failed_chunks + f.cancelled_chunks, f.total_chunks)
+            f.updated_at = _now()
+            self._recompute_task_progress(task)
+
+    async def _is_cancel_requested(self, task_id: str) -> bool:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return True
+            return task.status == "cancel_requested"
+
+    def _find_file(self, task: ImportTaskRecord, file_id: str) -> Optional[ImportFileRecord]:
+        for f in task.files:
+            if f.file_id == file_id:
+                return f
+        return None
+
+    def _find_chunk(self, file_record: ImportFileRecord, chunk_id: str) -> Optional[ImportChunkRecord]:
+        for c in file_record.chunks:
+            if c.chunk_id == chunk_id:
+                return c
+        return None
+
+    def _compute_ratio(self, done: int, total: int) -> float:
+        if total <= 0:
+            return 1.0
+        return max(0.0, min(1.0, float(done) / float(total)))
+
+    def _recompute_task_progress(self, task: ImportTaskRecord) -> None:
+        total = 0
+        done = 0
+        failed = 0
+        cancelled = 0
+        for f in task.files:
+            total += f.total_chunks
+            done += f.done_chunks
+            failed += f.failed_chunks
+            cancelled += f.cancelled_chunks
+        task.total_chunks = total
+        task.done_chunks = done
+        task.failed_chunks = failed
+        task.cancelled_chunks = cancelled
+        task.progress = self._compute_ratio(done + failed + cancelled, total)
+        task.updated_at = _now()
+
+    async def _should_cleanup_task_temp(self, task_id: str) -> bool:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return True
+            for f in task.files:
+                if f.status == "failed":
+                    return False
+            return True
+
+    def _mark_task_cancelled_locked(self, task: ImportTaskRecord, reason: str) -> None:
+        for f in task.files:
+            if f.status in {"completed", "failed", "cancelled"}:
+                continue
+            f.status = "cancelled"
+            f.current_step = "cancelled"
+            f.error = reason
+            additional_cancelled = 0
+            for c in f.chunks:
+                if c.status in {"completed", "failed", "cancelled"}:
+                    continue
+                c.status = "cancelled"
+                c.step = "cancelled"
+                c.retryable = False
+                c.error = reason
+                c.progress = 1.0
+                c.updated_at = _now()
+                additional_cancelled += 1
+            if additional_cancelled > 0:
+                f.cancelled_chunks += additional_cancelled
+            f.progress = self._compute_ratio(
+                f.done_chunks + f.failed_chunks + f.cancelled_chunks, f.total_chunks
+            )
+            f.updated_at = _now()
+        task.status = "cancelled"
+        task.current_step = "cancelled"
+        task.finished_at = _now()
+        task.updated_at = _now()
+        self._recompute_task_progress(task)

--- a/plugin.py
+++ b/plugin.py
@@ -123,12 +123,25 @@ class A_MemorixPlugin(BasePlugin):
 
     # 插件基本信息（PluginBase要求的抽象属性）
     plugin_name = "A_Memorix"
-    plugin_version = "0.5.1"
+    plugin_version = "0.6.0"
     plugin_description = "轻量级知识库插件 - 含人物画像能力的独立记忆增强系统"
     plugin_author = "A_Dawn"
     enable_plugin = False  # 默认禁用，需要在config.toml中启用
     dependencies: list[str] = []
-    python_dependencies: list[str] = ["numpy", "scipy", "nest-asyncio", "faiss-cpu", "fastapi", "uvicorn", "pydantic", "jieba"]  # 插件所需Python依赖
+    python_dependencies: list[str] = [
+        "numpy",
+        "scipy",
+        "networkx",
+        "pyarrow",
+        "pandas",
+        "nest-asyncio",
+        "faiss-cpu",
+        "fastapi",
+        "uvicorn",
+        "pydantic",
+        "python-multipart",
+        "jieba",
+    ]  # 插件所需Python依赖
     config_file_name: str = "config.toml"
 
     # 配置节描述
@@ -154,7 +167,7 @@ class A_MemorixPlugin(BasePlugin):
         "plugin": {
             "config_version": ConfigField(
                 type=str,
-                default="4.0.1",
+                default="4.1.0",
                 description="配置文件版本"
             ),
             "enabled": ConfigField(
@@ -200,10 +213,11 @@ class A_MemorixPlugin(BasePlugin):
                 type=dict,
                 default={
                     "max_attempts": 5,
-                    "max_wait_seconds": 30,
-                    "min_wait_seconds": 2,
+                    "max_wait_seconds": 40,
+                    "min_wait_seconds": 3,
+                    "backoff_multiplier": 3,
                 },
-                description="嵌入重试配置: max_attempts, max_wait_seconds, min_wait_seconds"
+                description="嵌入重试配置: max_attempts, min_wait_seconds, max_wait_seconds, backoff_multiplier"
             ),
         },
         "retrieval": {
@@ -372,6 +386,38 @@ class A_MemorixPlugin(BasePlugin):
                 type=str,
                 default="0.0.0.0",
                 description="服务器绑定地址"
+            ),
+            "import": ConfigField(
+                type=dict,
+                default={
+                    "enabled": True,
+                    "max_queue_size": 20,
+                    "max_files_per_task": 200,
+                    "max_file_size_mb": 20,
+                    "max_paste_chars": 200000,
+                    "default_file_concurrency": 2,
+                    "default_chunk_concurrency": 4,
+                    "max_file_concurrency": 6,
+                    "max_chunk_concurrency": 12,
+                    "poll_interval_ms": 1000,
+                    "token": "",
+                    "path_aliases": {
+                        "raw": "./plugins/A_memorix/data/raw",
+                        "lpmm": "./data/lpmm_storage",
+                        "plugin_data": "./plugins/A_memorix/data",
+                    },
+                    "llm_retry": {
+                        "max_attempts": 4,
+                        "min_wait_seconds": 3,
+                        "max_wait_seconds": 40,
+                        "backoff_multiplier": 3,
+                    },
+                    "convert": {
+                        "enable_staging_switch": True,
+                        "keep_backup_count": 3,
+                    },
+                },
+                description="Web 导入中心配置（队列、并发、大小限制、鉴权）"
             ),
         },
         "advanced": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,15 @@ numpy>=1.20.0
 # 稀疏矩阵 - 用于图存储的邻接矩阵
 scipy>=1.7.0
 
+# 图结构处理（LPMM 转换）
+networkx>=3.0.0
+
+# Parquet 读取（LPMM 转换）
+pyarrow>=10.0.0
+
+# DataFrame 处理（LPMM 转换）
+pandas>=1.5.0
+
 # 异步事件循环嵌套 - 用于插件初始化时的异步操作
 nest-asyncio>=1.5.0
 
@@ -26,6 +35,7 @@ fastapi>=0.100.0
 
 # 数据验证
 pydantic>=2.0.0
+python-multipart>=0.0.9
 
 # 注意事项
 # ==================

--- a/scripts/migrate_maibot_memory.py
+++ b/scripts/migrate_maibot_memory.py
@@ -1,0 +1,1635 @@
+#!/usr/bin/env python3
+"""
+MaiBot 记忆迁移脚本（chat_history -> A_memorix）
+
+特性：
+1. 高性能：分页读取 + 批量 embedding + 批量写入
+2. 断点续传：基于 last_committed_id 的窗口提交
+3. 精确一次语义：稳定哈希 + 幂等写入 + 向量存在性检查
+4. 可确认筛选：支持时间区间、聊天流（stream/group/user）筛选，并先预览后确认
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib
+import json
+import logging
+import os
+import pickle
+import sqlite3
+import sys
+import time
+import types
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import tomlkit
+
+
+CURRENT_DIR = Path(__file__).resolve().parent
+PLUGIN_ROOT = CURRENT_DIR.parent
+PROJECT_ROOT = PLUGIN_ROOT.parent.parent
+RUNTIME_CORE_PACKAGE = "_a_memorix_runtime_core"
+
+VectorStore = None
+GraphStore = None
+MetadataStore = None
+create_embedding_api_adapter = None
+KnowledgeType = None
+QuantizationType = None
+SparseMatrixFormat = None
+compute_hash = None
+normalize_text = None
+atomic_write = None
+model_config = None
+
+
+logger = logging.getLogger("A_Memorix.MaiBotMigration")
+logger.addHandler(logging.NullHandler())
+
+
+def _ensure_import_paths() -> None:
+    project_root_str = str(PROJECT_ROOT)
+    plugin_root_str = str(PLUGIN_ROOT)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+    if plugin_root_str not in sys.path:
+        sys.path.insert(0, plugin_root_str)
+
+
+def _ensure_runtime_core_package() -> str:
+    existing = sys.modules.get(RUNTIME_CORE_PACKAGE)
+    if existing is not None and hasattr(existing, "__path__"):
+        return RUNTIME_CORE_PACKAGE
+
+    pkg = types.ModuleType(RUNTIME_CORE_PACKAGE)
+    pkg.__path__ = [str(PLUGIN_ROOT / "core")]
+    pkg.__package__ = RUNTIME_CORE_PACKAGE
+    sys.modules[RUNTIME_CORE_PACKAGE] = pkg
+    return RUNTIME_CORE_PACKAGE
+
+
+def _disable_unavailable_gemini_provider() -> None:
+    global model_config
+    try:
+        from google import genai  # type: ignore  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    from src.config.config import model_config as loaded_model_config
+
+    providers = list(getattr(loaded_model_config, "api_providers", []))
+    if not providers:
+        model_config = loaded_model_config
+        return
+
+    kept_providers = [p for p in providers if str(getattr(p, "client_type", "")).lower() != "gemini"]
+    if len(kept_providers) == len(providers):
+        model_config = loaded_model_config
+        return
+
+    loaded_model_config.api_providers = kept_providers
+    loaded_model_config.api_providers_dict = {p.name: p for p in kept_providers}
+
+    models = list(getattr(loaded_model_config, "models", []))
+    kept_models = [m for m in models if m.api_provider in loaded_model_config.api_providers_dict]
+    loaded_model_config.models = kept_models
+    loaded_model_config.models_dict = {m.name: m for m in kept_models}
+
+    task_cfg = loaded_model_config.model_task_config
+    for field_name in task_cfg.__dataclass_fields__.keys():
+        task = getattr(task_cfg, field_name, None)
+        if task is None or not hasattr(task, "model_list"):
+            continue
+        task.model_list = [m for m in list(task.model_list) if m in loaded_model_config.models_dict]
+
+    model_config = loaded_model_config
+    logger.warning("检测到缺少 google.genai，已临时禁用 gemini provider 以保证脚本可运行。")
+
+
+def _bootstrap_runtime_symbols() -> None:
+    global VectorStore
+    global GraphStore
+    global MetadataStore
+    global KnowledgeType
+    global QuantizationType
+    global SparseMatrixFormat
+    global compute_hash
+    global normalize_text
+    global atomic_write
+    global logger
+
+    if VectorStore is not None and compute_hash is not None and atomic_write is not None:
+        return
+
+    _ensure_import_paths()
+
+    import src  # noqa: F401
+    from src.common.logger import get_logger
+
+    logger = get_logger("A_Memorix.MaiBotMigration")
+
+    pkg = _ensure_runtime_core_package()
+
+    vector_store_module = importlib.import_module(f"{pkg}.storage.vector_store")
+    graph_store_module = importlib.import_module(f"{pkg}.storage.graph_store")
+    metadata_store_module = importlib.import_module(f"{pkg}.storage.metadata_store")
+    knowledge_types_module = importlib.import_module(f"{pkg}.storage.knowledge_types")
+    hash_module = importlib.import_module(f"{pkg}.utils.hash")
+    io_module = importlib.import_module(f"{pkg}.utils.io")
+
+    VectorStore = vector_store_module.VectorStore
+    GraphStore = graph_store_module.GraphStore
+    MetadataStore = metadata_store_module.MetadataStore
+    KnowledgeType = knowledge_types_module.KnowledgeType
+    QuantizationType = vector_store_module.QuantizationType
+    SparseMatrixFormat = graph_store_module.SparseMatrixFormat
+    compute_hash = hash_module.compute_hash
+    normalize_text = hash_module.normalize_text
+    atomic_write = io_module.atomic_write
+
+
+def _load_embedding_adapter_factory() -> None:
+    global create_embedding_api_adapter
+    global model_config
+
+    if create_embedding_api_adapter is not None:
+        return
+
+    _ensure_import_paths()
+
+    from src.config.config import model_config as loaded_model_config
+
+    model_config = loaded_model_config
+    _disable_unavailable_gemini_provider()
+
+    pkg = _ensure_runtime_core_package()
+    api_adapter_module = importlib.import_module(f"{pkg}.embedding.api_adapter")
+    create_embedding_api_adapter = api_adapter_module.create_embedding_api_adapter
+
+
+DEFAULT_SOURCE_DB = PROJECT_ROOT / "data" / "MaiBot.db"
+DEFAULT_TARGET_DATA_DIR = PLUGIN_ROOT / "data"
+DEFAULT_CONFIG_PATH = PLUGIN_ROOT / "config.toml"
+
+MIGRATION_STATE_DIRNAME = "migration_state"
+STATE_FILENAME = "chat_history_resume.json"
+BAD_ROWS_FILENAME = "chat_history_bad_rows.jsonl"
+REPORT_FILENAME = "chat_history_report.json"
+
+
+class MigrationError(Exception):
+    """迁移流程错误。"""
+
+
+@dataclass
+class SelectionFilter:
+    time_from_ts: Optional[float]
+    time_to_ts: Optional[float]
+    stream_ids: List[str]
+    stream_filter_requested: bool
+    start_id: Optional[int]
+    end_id: Optional[int]
+    time_from_raw: Optional[str]
+    time_to_raw: Optional[str]
+
+    def fingerprint_payload(self) -> Dict[str, Any]:
+        return {
+            "time_from_ts": self.time_from_ts,
+            "time_to_ts": self.time_to_ts,
+            "time_from_raw": self.time_from_raw,
+            "time_to_raw": self.time_to_raw,
+            "stream_ids": sorted(self.stream_ids),
+            "stream_filter_requested": self.stream_filter_requested,
+            "start_id": self.start_id,
+            "end_id": self.end_id,
+        }
+
+
+@dataclass
+class PreviewResult:
+    total: int
+    distribution: List[Tuple[str, int]]
+    samples: List[Dict[str, Any]]
+
+
+@dataclass
+class MappedRow:
+    row_id: int
+    chat_id: str
+    paragraph_hash: str
+    content: str
+    source: str
+    time_meta: Dict[str, Any]
+    entities: List[str]
+    relations: List[Tuple[str, str, str]]
+    existing_paragraph_vector: bool
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _safe_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _normalize_name(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _canonical_name(value: Any) -> str:
+    return _normalize_name(value).lower()
+
+
+def _dedup_keep_order(items: Iterable[str]) -> List[str]:
+    out: List[str] = []
+    seen: set[str] = set()
+    for raw in items:
+        v = _normalize_name(raw)
+        if not v:
+            continue
+        k = v.lower()
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(v)
+    return out
+
+
+def _format_ts(ts: Optional[float]) -> str:
+    if ts is None:
+        return "-"
+    try:
+        return datetime.fromtimestamp(float(ts)).strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return str(ts)
+
+
+def _parse_cli_datetime(text: str, is_end: bool = False) -> float:
+    value = str(text or "").strip()
+    if not value:
+        raise ValueError("时间不能为空")
+
+    formats = [
+        ("%Y-%m-%d %H:%M:%S", False),
+        ("%Y/%m/%d %H:%M:%S", False),
+        ("%Y-%m-%d %H:%M", False),
+        ("%Y/%m/%d %H:%M", False),
+        ("%Y-%m-%d", True),
+        ("%Y/%m/%d", True),
+    ]
+
+    for fmt, is_date_only in formats:
+        try:
+            dt = datetime.strptime(value, fmt)
+            if is_date_only and is_end:
+                dt = dt.replace(hour=23, minute=59, second=59, microsecond=0)
+            return dt.timestamp()
+        except ValueError:
+            continue
+
+    raise ValueError(
+        f"时间格式错误: {value}，仅支持 YYYY-MM-DD、YYYY/MM/DD、YYYY-MM-DD HH:mm[:ss]、YYYY/MM/DD HH:mm[:ss]"
+    )
+
+
+def _json_hash(payload: Dict[str, Any]) -> str:
+    data = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha1(data.encode("utf-8")).hexdigest()
+
+
+def _deep_merge_dict(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge_dict(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def _extract_schema_defaults(schema_obj: Dict[str, Any]) -> Dict[str, Any]:
+    defaults: Dict[str, Any] = {}
+    if not isinstance(schema_obj, dict):
+        return defaults
+
+    for key, spec in schema_obj.items():
+        if not isinstance(spec, dict):
+            continue
+        if "default" in spec:
+            defaults[key] = spec.get("default")
+            continue
+        props = spec.get("properties")
+        if isinstance(props, dict):
+            defaults[key] = _extract_schema_defaults(props)
+    return defaults
+
+
+def _load_manifest_defaults() -> Dict[str, Any]:
+    manifest_path = PLUGIN_ROOT / "_manifest.json"
+    if not manifest_path.exists():
+        return {}
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        schema = payload.get("config_schema")
+        if isinstance(schema, dict):
+            return _extract_schema_defaults(schema)
+    except Exception as e:
+        logger.warning(f"读取 manifest 默认配置失败，已回退空配置: {e}")
+    return {}
+
+
+def _build_source_db_fingerprint(db_path: Path) -> Dict[str, Any]:
+    stat = db_path.stat()
+    payload = {
+        "path": str(db_path.resolve()),
+        "size": stat.st_size,
+        "mtime": stat.st_mtime,
+    }
+    payload["sha1"] = _json_hash(payload)
+    return payload
+
+
+def _state_path(target_data_dir: Path) -> Path:
+    return target_data_dir / MIGRATION_STATE_DIRNAME / STATE_FILENAME
+
+
+def _bad_rows_path(target_data_dir: Path) -> Path:
+    return target_data_dir / MIGRATION_STATE_DIRNAME / BAD_ROWS_FILENAME
+
+
+def _report_path(target_data_dir: Path) -> Path:
+    return target_data_dir / MIGRATION_STATE_DIRNAME / REPORT_FILENAME
+
+
+def _dump_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    if atomic_write is None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+        return
+
+    with atomic_write(path, mode="w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+
+class SourceDB:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self.conn: Optional[sqlite3.Connection] = None
+
+    def connect(self) -> None:
+        if not self.db_path.exists():
+            raise MigrationError(f"源数据库不存在: {self.db_path}")
+
+        uri = f"file:{self.db_path.resolve().as_posix()}?mode=ro"
+        try:
+            self.conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+        except sqlite3.OperationalError:
+            self.conn = sqlite3.connect(str(self.db_path.resolve()), check_same_thread=False)
+
+        self.conn.row_factory = sqlite3.Row
+        pragmas = [
+            "PRAGMA query_only = ON",
+            "PRAGMA cache_size = -128000",
+            "PRAGMA temp_store = MEMORY",
+            "PRAGMA synchronous = OFF",
+            "PRAGMA journal_mode = WAL",
+        ]
+        for sql in pragmas:
+            try:
+                self.conn.execute(sql)
+            except sqlite3.OperationalError:
+                # 部分 PRAGMA 在 mode=ro 下会失败，不影响只读扫描能力
+                continue
+
+    def close(self) -> None:
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+
+    def _require_conn(self) -> sqlite3.Connection:
+        if self.conn is None:
+            raise MigrationError("源数据库尚未连接")
+        return self.conn
+
+    def resolve_stream_ids(
+        self,
+        stream_ids: Sequence[str],
+        group_ids: Sequence[str],
+        user_ids: Sequence[str],
+    ) -> List[str]:
+        conn = self._require_conn()
+        resolved: set[str] = set(_normalize_name(x) for x in stream_ids if _normalize_name(x))
+        has_group_or_user = any(_normalize_name(x) for x in group_ids) or any(_normalize_name(x) for x in user_ids)
+        if not has_group_or_user:
+            return sorted(resolved)
+
+        table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chat_streams' LIMIT 1"
+        ).fetchone()
+        if table_exists is None:
+            raise MigrationError("源库缺少 chat_streams 表，无法根据 --group-id/--user-id 映射 stream_id")
+
+        def _select_by_field(field: str, values: Sequence[str]) -> None:
+            values_norm = [_normalize_name(v) for v in values if _normalize_name(v)]
+            if not values_norm:
+                return
+            placeholders = ",".join("?" for _ in values_norm)
+            sql = f"SELECT DISTINCT stream_id FROM chat_streams WHERE {field} IN ({placeholders})"
+            cur = conn.execute(sql, tuple(values_norm))
+            for row in cur.fetchall():
+                sid = _normalize_name(row["stream_id"])
+                if sid:
+                    resolved.add(sid)
+
+        _select_by_field("group_id", group_ids)
+        _select_by_field("user_id", user_ids)
+        return sorted(resolved)
+
+    @staticmethod
+    def _build_where(
+        selection: SelectionFilter,
+        start_after_id: Optional[int] = None,
+    ) -> Tuple[str, List[Any]]:
+        conditions: List[str] = []
+        params: List[Any] = []
+
+        if selection.start_id is not None:
+            conditions.append("id >= ?")
+            params.append(selection.start_id)
+        if selection.end_id is not None:
+            conditions.append("id <= ?")
+            params.append(selection.end_id)
+        if start_after_id is not None:
+            conditions.append("id > ?")
+            params.append(start_after_id)
+
+        if selection.stream_ids:
+            placeholders = ",".join("?" for _ in selection.stream_ids)
+            conditions.append(f"chat_id IN ({placeholders})")
+            params.extend(selection.stream_ids)
+        elif selection.stream_filter_requested:
+            conditions.append("1=0")
+
+        if selection.time_from_ts is not None and selection.time_to_ts is not None:
+            conditions.append("(end_time >= ? AND start_time <= ?)")
+            params.extend([selection.time_from_ts, selection.time_to_ts])
+        elif selection.time_from_ts is not None:
+            conditions.append("(end_time >= ?)")
+            params.append(selection.time_from_ts)
+        elif selection.time_to_ts is not None:
+            conditions.append("(start_time <= ?)")
+            params.append(selection.time_to_ts)
+
+        where_sql = "WHERE " + " AND ".join(conditions) if conditions else ""
+        return where_sql, params
+
+    def count_candidates(self, selection: SelectionFilter) -> int:
+        conn = self._require_conn()
+        where_sql, params = self._build_where(selection, start_after_id=None)
+        sql = f"SELECT COUNT(*) AS c FROM chat_history {where_sql}"
+        cur = conn.execute(sql, tuple(params))
+        return int(cur.fetchone()["c"])
+
+    def preview(self, selection: SelectionFilter, preview_limit: int) -> PreviewResult:
+        conn = self._require_conn()
+        where_sql, params = self._build_where(selection, start_after_id=None)
+
+        total_sql = f"SELECT COUNT(*) AS c FROM chat_history {where_sql}"
+        total = int(conn.execute(total_sql, tuple(params)).fetchone()["c"])
+
+        dist_sql = (
+            f"SELECT chat_id, COUNT(*) AS c FROM chat_history {where_sql} "
+            "GROUP BY chat_id ORDER BY c DESC LIMIT 30"
+        )
+        distribution = [
+            (_normalize_name(row["chat_id"]), int(row["c"]))
+            for row in conn.execute(dist_sql, tuple(params)).fetchall()
+        ]
+
+        sample_sql = (
+            "SELECT id, chat_id, start_time, end_time, theme, summary "
+            f"FROM chat_history {where_sql} ORDER BY id ASC LIMIT ?"
+        )
+        sample_params = list(params)
+        sample_params.append(max(1, int(preview_limit)))
+        samples = [dict(row) for row in conn.execute(sample_sql, tuple(sample_params)).fetchall()]
+
+        return PreviewResult(total=total, distribution=distribution, samples=samples)
+
+    def iter_rows(
+        self,
+        selection: SelectionFilter,
+        batch_size: int,
+        start_after_id: int,
+    ) -> Generator[List[sqlite3.Row], None, None]:
+        conn = self._require_conn()
+        cursor = int(start_after_id)
+        while True:
+            where_sql, params = self._build_where(selection, start_after_id=cursor)
+            sql = (
+                "SELECT id, chat_id, start_time, end_time, participants, theme, keywords, summary "
+                f"FROM chat_history {where_sql} ORDER BY id ASC LIMIT ?"
+            )
+            bind = list(params)
+            bind.append(max(1, int(batch_size)))
+            rows = conn.execute(sql, tuple(bind)).fetchall()
+            if not rows:
+                break
+            yield rows
+            cursor = int(rows[-1]["id"])
+
+    def sample_rows_for_verify(
+        self,
+        selection: SelectionFilter,
+        sample_size: int,
+    ) -> List[sqlite3.Row]:
+        conn = self._require_conn()
+        where_sql, params = self._build_where(selection, start_after_id=None)
+        sql = (
+            "SELECT id, chat_id, start_time, end_time, participants, theme, keywords, summary "
+            f"FROM chat_history {where_sql} ORDER BY RANDOM() LIMIT ?"
+        )
+        bind = list(params)
+        bind.append(max(1, int(sample_size)))
+        return conn.execute(sql, tuple(bind)).fetchall()
+
+
+class MigrationRunner:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.source_db_path = Path(args.source_db).resolve()
+        self.target_data_dir = Path(args.target_data_dir).resolve()
+        self.state_file = _state_path(self.target_data_dir)
+        self.bad_rows_file = _bad_rows_path(self.target_data_dir)
+        self.report_file = _report_path(self.target_data_dir)
+
+        self.source_db = SourceDB(self.source_db_path)
+
+        self.vector_store = None
+        self.graph_store = None
+        self.metadata_store = None
+        self.embedding_manager = None
+        self.plugin_config: Dict[str, Any] = {}
+        self.embed_workers: int = 5
+
+        self.selection: Optional[SelectionFilter] = None
+        self.filter_fingerprint: str = ""
+        self.source_db_fingerprint: Dict[str, Any] = {}
+        self.source_db_fingerprint_hash: str = ""
+        self.state: Dict[str, Any] = {}
+
+        self.started_at = time.time()
+        self.exit_code = 0
+        self.failed = False
+        self.fail_reason: Optional[str] = None
+
+        self.stats: Dict[str, Any] = {
+            "source_matched_total": 0,
+            "scanned_rows": 0,
+            "valid_rows": 0,
+            "migrated_rows": 0,
+            "skipped_existing_rows": 0,
+            "bad_rows": 0,
+            "paragraph_vectors_added": 0,
+            "entity_vectors_added": 0,
+            "relations_written": 0,
+            "graph_edges_written": 0,
+            "windows_committed": 0,
+            "last_committed_id": 0,
+            "verify_sample_size": 0,
+            "verify_paragraph_missing": 0,
+            "verify_vector_missing": 0,
+            "verify_relation_missing": 0,
+            "verify_edge_missing": 0,
+            "verify_passed": False,
+        }
+
+    async def run(self) -> int:
+        try:
+            _bootstrap_runtime_symbols()
+            self._prepare_paths()
+
+            self.source_db.connect()
+            self.selection = self._build_selection_filter()
+            self.filter_fingerprint = _json_hash(self.selection.fingerprint_payload())
+
+            self.source_db_fingerprint = _build_source_db_fingerprint(self.source_db_path)
+            self.source_db_fingerprint_hash = str(self.source_db_fingerprint.get("sha1", ""))
+
+            preview = self.source_db.preview(self.selection, preview_limit=self.args.preview_limit)
+            self.stats["source_matched_total"] = int(preview.total)
+            self._print_preview(preview)
+
+            if preview.total <= 0:
+                logger.info("筛选后无数据，退出。")
+                self.stats["verify_passed"] = True
+                if self.args.verify_only:
+                    self._load_plugin_config()
+                    await self._init_target_stores(require_embedding=False)
+                    await self._verify(strict=True)
+                return self._finalize()
+
+            if self.args.verify_only:
+                self._load_plugin_config()
+                await self._init_target_stores(require_embedding=False)
+                await self._verify(strict=True)
+                return self._finalize()
+
+            if self.args.dry_run:
+                logger.info("dry-run 模式：仅预览，不写入。")
+                return self._finalize()
+
+            if not self.args.yes:
+                if not self._confirm():
+                    logger.info("用户取消执行。")
+                    return self._finalize()
+
+            self._load_plugin_config()
+            await self._init_target_stores(require_embedding=True)
+            self._load_or_init_state()
+
+            start_after_id = self._resolve_start_after_id()
+            await self._migrate(start_after_id=start_after_id)
+            await self._verify(strict=True)
+            return self._finalize()
+        except Exception as e:
+            self.failed = True
+            self.fail_reason = str(e)
+            logger.error(f"迁移失败: {e}", exc_info=True)
+            return self._finalize()
+        finally:
+            self._close()
+
+    def _prepare_paths(self) -> None:
+        (self.target_data_dir / MIGRATION_STATE_DIRNAME).mkdir(parents=True, exist_ok=True)
+        if self.args.reset_state and self.state_file.exists():
+            self.state_file.unlink()
+        if self.args.reset_state and self.bad_rows_file.exists():
+            self.bad_rows_file.unlink()
+
+    def _load_plugin_config(self) -> None:
+        merged = _load_manifest_defaults()
+
+        config_path = DEFAULT_CONFIG_PATH
+        if config_path.exists():
+            try:
+                with open(config_path, "r", encoding="utf-8") as f:
+                    raw = tomlkit.load(f)
+                if isinstance(raw, dict):
+                    merged = _deep_merge_dict(merged, dict(raw))
+            except Exception as e:
+                logger.warning(f"读取插件配置失败，继续使用默认配置: {e}")
+
+        self.plugin_config = merged
+
+    def _read_existing_vector_dimension(self, fallback_dimension: int) -> int:
+        meta_path = self.target_data_dir / "vectors" / "vectors_metadata.pkl"
+        if not meta_path.exists():
+            return fallback_dimension
+        try:
+            with open(meta_path, "rb") as f:
+                payload = pickle.load(f)
+            value = _safe_int(payload.get("dimension"), fallback_dimension)
+            return max(1, value)
+        except Exception:
+            return fallback_dimension
+
+    async def _init_target_stores(self, require_embedding: bool) -> None:
+        if VectorStore is None or GraphStore is None or MetadataStore is None:
+            raise MigrationError("运行时初始化失败：存储组件不可用")
+
+        emb_cfg = self.plugin_config.get("embedding", {}) if isinstance(self.plugin_config, dict) else {}
+        graph_cfg = self.plugin_config.get("graph", {}) if isinstance(self.plugin_config, dict) else {}
+
+        self.embed_workers = max(1, _safe_int(self.args.embed_workers, _safe_int(emb_cfg.get("max_concurrent"), 5)))
+        emb_batch_size = max(1, _safe_int(emb_cfg.get("batch_size"), 32))
+        emb_default_dim = max(1, _safe_int(emb_cfg.get("dimension"), 1024))
+        emb_model_name = str(emb_cfg.get("model_name", "auto"))
+        emb_retry = emb_cfg.get("retry", {}) if isinstance(emb_cfg.get("retry", {}), dict) else {}
+
+        if require_embedding:
+            _load_embedding_adapter_factory()
+            if create_embedding_api_adapter is None:
+                raise MigrationError("运行时初始化失败：embedding 适配器不可用")
+
+            if model_config is not None:
+                embedding_task = getattr(getattr(model_config, "model_task_config", None), "embedding", None)
+                if embedding_task is not None and hasattr(embedding_task, "model_list"):
+                    if not list(embedding_task.model_list):
+                        raise MigrationError(
+                            "当前配置没有可用 embedding 模型。若你使用 gemini provider，请先安装 `google-genai` "
+                            "或切换到可用的 embedding provider。"
+                        )
+
+            self.embedding_manager = create_embedding_api_adapter(
+                batch_size=emb_batch_size,
+                max_concurrent=self.embed_workers,
+                default_dimension=emb_default_dim,
+                model_name=emb_model_name,
+                retry_config=emb_retry,
+            )
+
+            try:
+                detected_dim = self._read_existing_vector_dimension(emb_default_dim)
+                has_existing_vectors = (self.target_data_dir / "vectors" / "vectors_metadata.pkl").exists()
+                if not has_existing_vectors:
+                    detected_dim = await self.embedding_manager._detect_dimension()
+            except Exception as e:
+                logger.warning(f"嵌入维度探测失败，回退配置维度: {e}")
+                detected_dim = self._read_existing_vector_dimension(emb_default_dim)
+        else:
+            detected_dim = self._read_existing_vector_dimension(emb_default_dim)
+            self.embedding_manager = None
+
+        q_type = str(emb_cfg.get("quantization_type", "int8")).lower()
+        q_map = {
+            "float32": QuantizationType.FLOAT32,
+            "int8": QuantizationType.INT8,
+            "pq": QuantizationType.PQ,
+        }
+        quantization = q_map.get(q_type, QuantizationType.INT8)
+
+        matrix_fmt = str(graph_cfg.get("sparse_matrix_format", "csr")).lower()
+        fmt_map = {
+            "csr": SparseMatrixFormat.CSR,
+            "csc": SparseMatrixFormat.CSC,
+        }
+        sparse_fmt = fmt_map.get(matrix_fmt, SparseMatrixFormat.CSR)
+
+        self.vector_store = VectorStore(
+            dimension=detected_dim,
+            quantization_type=quantization,
+            data_dir=self.target_data_dir / "vectors",
+        )
+        self.graph_store = GraphStore(
+            matrix_format=sparse_fmt,
+            data_dir=self.target_data_dir / "graph",
+        )
+        self.metadata_store = MetadataStore(data_dir=self.target_data_dir / "metadata")
+        self.metadata_store.connect()
+
+        if self.vector_store.has_data():
+            self.vector_store.load()
+        if self.graph_store.has_data():
+            self.graph_store.load()
+
+        logger.info(
+            f"目标存储初始化完成: dim={self.vector_store.dimension}, quant={q_type}, graph_fmt={matrix_fmt}, "
+            f"embed_workers={self.embed_workers}"
+        )
+
+    def _build_selection_filter(self) -> SelectionFilter:
+        if self.args.start_id is not None and self.args.start_id <= 0:
+            raise MigrationError("--start-id 必须 > 0")
+        if self.args.end_id is not None and self.args.end_id <= 0:
+            raise MigrationError("--end-id 必须 > 0")
+        if self.args.start_id is not None and self.args.end_id is not None and self.args.start_id > self.args.end_id:
+            raise MigrationError("--start-id 不能大于 --end-id")
+
+        time_from_ts = _parse_cli_datetime(self.args.time_from, is_end=False) if self.args.time_from else None
+        time_to_ts = _parse_cli_datetime(self.args.time_to, is_end=True) if self.args.time_to else None
+        if time_from_ts is not None and time_to_ts is not None and time_from_ts > time_to_ts:
+            raise MigrationError("--time-from 不能晚于 --time-to")
+
+        stream_filter_requested = bool(
+            (self.args.stream_id or []) or (self.args.group_id or []) or (self.args.user_id or [])
+        )
+        stream_ids = self.source_db.resolve_stream_ids(
+            stream_ids=self.args.stream_id or [],
+            group_ids=self.args.group_id or [],
+            user_ids=self.args.user_id or [],
+        )
+        if stream_filter_requested and not stream_ids:
+            logger.warning("已指定 stream/group/user 筛选，但未解析到任何 stream_id，结果将为空。")
+
+        logger.info(
+            f"筛选条件: time_from={self.args.time_from or '-'}, time_to={self.args.time_to or '-'}, "
+            f"stream_ids={len(stream_ids)}, stream_filter_requested={stream_filter_requested}"
+        )
+
+        return SelectionFilter(
+            time_from_ts=time_from_ts,
+            time_to_ts=time_to_ts,
+            stream_ids=stream_ids,
+            stream_filter_requested=stream_filter_requested,
+            start_id=self.args.start_id,
+            end_id=self.args.end_id,
+            time_from_raw=self.args.time_from,
+            time_to_raw=self.args.time_to,
+        )
+
+    def _load_or_init_state(self) -> None:
+        if self.args.start_id is not None:
+            logger.info("检测到 --start-id，已按用户指定起点覆盖断点状态。")
+            self.state = self._new_state(last_committed_id=int(self.args.start_id) - 1)
+            return
+
+        if self.args.no_resume:
+            self.state = self._new_state(last_committed_id=0)
+            return
+
+        if not self.state_file.exists():
+            self.state = self._new_state(last_committed_id=0)
+            return
+
+        with open(self.state_file, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+
+        loaded_filter_fp = str(loaded.get("filter_fingerprint", ""))
+        loaded_source_fp = str(loaded.get("source_db_fingerprint", ""))
+
+        if loaded_filter_fp != self.filter_fingerprint or loaded_source_fp != self.source_db_fingerprint_hash:
+            if self.args.dry_run or self.args.verify_only:
+                logger.info("检测到断点与当前筛选不一致；当前为只读模式，将忽略旧断点。")
+                self.state = self._new_state(last_committed_id=0)
+                return
+            raise MigrationError(
+                "检测到筛选条件或源库指纹变化，已拒绝继续续传。请使用 --reset-state 或调整参数后重试。"
+            )
+
+        self.state = loaded
+        stored_stats = loaded.get("stats", {})
+        if isinstance(stored_stats, dict):
+            for k, v in stored_stats.items():
+                if k in self.stats and isinstance(v, (int, float, bool)):
+                    self.stats[k] = v
+
+    def _new_state(self, last_committed_id: int) -> Dict[str, Any]:
+        return {
+            "version": 1,
+            "updated_at": time.time(),
+            "last_committed_id": int(last_committed_id),
+            "filter_fingerprint": self.filter_fingerprint,
+            "source_db_fingerprint": self.source_db_fingerprint_hash,
+            "source_db_meta": self.source_db_fingerprint,
+            "stats": dict(self.stats),
+        }
+
+    def _flush_state(self, last_committed_id: int) -> None:
+        self.stats["last_committed_id"] = int(last_committed_id)
+        self.state = {
+            "version": 1,
+            "updated_at": time.time(),
+            "last_committed_id": int(last_committed_id),
+            "filter_fingerprint": self.filter_fingerprint,
+            "source_db_fingerprint": self.source_db_fingerprint_hash,
+            "source_db_meta": self.source_db_fingerprint,
+            "stats": dict(self.stats),
+        }
+        _dump_json_atomic(self.state_file, self.state)
+
+    def _resolve_start_after_id(self) -> int:
+        if self.selection is None:
+            raise MigrationError("selection 未初始化")
+
+        if self.args.start_id is not None:
+            return int(self.args.start_id) - 1
+
+        if self.args.no_resume:
+            return 0
+
+        state_last = _safe_int(self.state.get("last_committed_id"), 0) if self.state else 0
+        return max(0, state_last)
+
+    def _print_preview(self, preview: PreviewResult) -> None:
+        print("\n=== Migration Preview ===")
+        print(f"source_db: {self.source_db_path}")
+        print(f"target_data_dir: {self.target_data_dir}")
+        if self.selection:
+            print(
+                f"time_window: [{self.selection.time_from_raw or '-'} ~ {self.selection.time_to_raw or '-'}] "
+                f"(ts: {_format_ts(self.selection.time_from_ts)} ~ {_format_ts(self.selection.time_to_ts)})"
+            )
+            print(
+                f"id_window: [{self.selection.start_id or '-'} ~ {self.selection.end_id or '-'}], "
+                f"selected_streams={len(self.selection.stream_ids)}"
+            )
+        print(f"matched_rows: {preview.total}")
+
+        if preview.distribution:
+            print("top_chat_distribution:")
+            for cid, cnt in preview.distribution[:10]:
+                print(f"  - {cid}: {cnt}")
+        else:
+            print("top_chat_distribution: (none)")
+
+        if preview.samples:
+            print(f"samples (first {len(preview.samples)}):")
+            for row in preview.samples:
+                summary_preview = _normalize_name(row.get("summary", ""))[:60]
+                theme_preview = _normalize_name(row.get("theme", ""))[:30]
+                print(
+                    f"  - id={row.get('id')} chat_id={row.get('chat_id')} "
+                    f"[{_format_ts(row.get('start_time'))} ~ {_format_ts(row.get('end_time'))}] "
+                    f"theme={theme_preview!r} summary={summary_preview!r}"
+                )
+        print("=========================\n")
+
+    def _confirm(self) -> bool:
+        answer = input("确认按以上筛选执行迁移？输入 y 继续 [y/N]: ").strip().lower()
+        return answer in {"y", "yes"}
+
+    def _parse_json_list_field(self, raw: Any, field_name: str, row_id: int) -> List[str]:
+        if raw is None:
+            return []
+        if isinstance(raw, list):
+            data = raw
+        elif isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+            except Exception as e:
+                raise ValueError(f"{field_name} JSON 解析失败: {e}") from e
+            if not isinstance(parsed, list):
+                raise ValueError(f"{field_name} JSON 必须是 list，当前为 {type(parsed).__name__}")
+            data = parsed
+        else:
+            raise ValueError(f"{field_name} 字段类型不支持: {type(raw).__name__}")
+        return _dedup_keep_order(str(x) for x in data if _normalize_name(x))
+
+    def _map_row(self, row: sqlite3.Row) -> MappedRow:
+        row_id = int(row["id"])
+        chat_id = _normalize_name(row["chat_id"])
+        theme = _normalize_name(row["theme"])
+        summary = _normalize_name(row["summary"])
+
+        participants = self._parse_json_list_field(row["participants"], "participants", row_id)
+        keywords = self._parse_json_list_field(row["keywords"], "keywords", row_id)
+        keywords_top = keywords[:8]
+
+        participants_text = "、".join(participants) if participants else ""
+        keywords_text = "、".join(keywords_top) if keywords_top else ""
+
+        content = (
+            f"话题：{theme}\n"
+            f"概括：{summary}\n"
+            f"参与者：{participants_text}\n"
+            f"关键词：{keywords_text}"
+        ).strip()
+
+        paragraph_hash = compute_hash(normalize_text(content))
+        source = f"maibot.chat_history:{chat_id}"
+
+        start_time = _safe_float(row["start_time"], 0.0)
+        end_time = _safe_float(row["end_time"], start_time)
+        time_meta = {
+            "event_time_start": start_time,
+            "event_time_end": end_time,
+            "time_granularity": "minute",
+            "time_confidence": 0.95,
+        }
+
+        entities = _dedup_keep_order([*participants, theme, *keywords_top])
+        relations: List[Tuple[str, str, str]] = []
+        if theme:
+            for participant in participants:
+                relations.append((participant, "参与话题", theme))
+            for keyword in keywords_top:
+                relations.append((theme, "关键词", keyword))
+
+        existing_vector = paragraph_hash in self.vector_store
+        return MappedRow(
+            row_id=row_id,
+            chat_id=chat_id,
+            paragraph_hash=paragraph_hash,
+            content=content,
+            source=source,
+            time_meta=time_meta,
+            entities=entities,
+            relations=relations,
+            existing_paragraph_vector=existing_vector,
+        )
+
+    def _append_bad_row(self, row: sqlite3.Row, reason: str) -> None:
+        payload = {
+            "id": int(row["id"]),
+            "chat_id": _normalize_name(row["chat_id"]),
+            "start_time": row["start_time"],
+            "end_time": row["end_time"],
+            "participants": row["participants"],
+            "theme": _normalize_name(row["theme"]),
+            "keywords": row["keywords"],
+            "summary": row["summary"],
+            "error": reason,
+            "timestamp": time.time(),
+        }
+        self.bad_rows_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.bad_rows_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(payload, ensure_ascii=False))
+            f.write("\n")
+
+    async def _migrate(self, start_after_id: int) -> None:
+        if self.selection is None:
+            raise MigrationError("selection 未初始化")
+
+        read_batch_size = max(1, int(self.args.read_batch_size))
+        commit_window_rows = max(1, int(self.args.commit_window_rows))
+        log_every = max(1, int(self.args.log_every))
+
+        window_rows: List[MappedRow] = []
+        window_scanned = 0
+        last_seen_id = start_after_id
+
+        logger.info(
+            f"开始迁移: start_after_id={start_after_id}, read_batch_size={read_batch_size}, "
+            f"commit_window_rows={commit_window_rows}"
+        )
+
+        for batch in self.source_db.iter_rows(self.selection, read_batch_size, start_after_id):
+            for row in batch:
+                row_id = int(row["id"])
+                last_seen_id = row_id
+                self.stats["scanned_rows"] += 1
+                window_scanned += 1
+
+                try:
+                    mapped = self._map_row(row)
+                except Exception as e:
+                    self.stats["bad_rows"] += 1
+                    self._append_bad_row(row, str(e))
+                    if self.stats["bad_rows"] > int(self.args.max_errors):
+                        raise MigrationError(
+                            f"坏行数量超过上限 max_errors={self.args.max_errors}，已中止。"
+                        )
+                    continue
+
+                self.stats["valid_rows"] += 1
+                if mapped.existing_paragraph_vector:
+                    self.stats["skipped_existing_rows"] += 1
+                else:
+                    self.stats["migrated_rows"] += 1
+                window_rows.append(mapped)
+
+                if window_scanned >= commit_window_rows:
+                    await self._commit_window(window_rows, last_seen_id)
+                    window_rows = []
+                    window_scanned = 0
+
+                if self.stats["scanned_rows"] % log_every == 0:
+                    logger.info(
+                        f"迁移进度: scanned={self.stats['scanned_rows']}/{self.stats['source_matched_total']}, "
+                        f"valid={self.stats['valid_rows']}, bad={self.stats['bad_rows']}, "
+                        f"last_id={last_seen_id}"
+                    )
+
+        if window_scanned > 0 or window_rows:
+            await self._commit_window(window_rows, last_seen_id)
+
+        logger.info(
+            f"迁移主流程完成: scanned={self.stats['scanned_rows']}, valid={self.stats['valid_rows']}, "
+            f"bad={self.stats['bad_rows']}, last_committed_id={self.stats['last_committed_id']}"
+        )
+
+    async def _commit_window(self, rows: List[MappedRow], last_seen_id: int) -> None:
+        if not rows:
+            self._flush_state(last_seen_id)
+            self.stats["windows_committed"] += 1
+            return
+
+        now_ts = time.time()
+        empty_meta_blob = pickle.dumps({})
+
+        conn = self.metadata_store._conn
+        if conn is None:
+            raise MigrationError("metadata_store 连接不可用")
+
+        cursor = conn.cursor()
+
+        # 批量查询本窗口内已存在的段落，保证重跑时 entity/mention 不重复累计
+        existing_paragraph_hashes: set[str] = set()
+        all_hashes = [item.paragraph_hash for item in rows]
+        for i in range(0, len(all_hashes), 800):
+            batch_hashes = all_hashes[i : i + 800]
+            if not batch_hashes:
+                continue
+            placeholders = ",".join("?" for _ in batch_hashes)
+            existing_rows = cursor.execute(
+                f"SELECT hash FROM paragraphs WHERE hash IN ({placeholders})",
+                tuple(batch_hashes),
+            ).fetchall()
+            for row in existing_rows:
+                existing_paragraph_hashes.add(str(row["hash"]))
+
+        paragraph_records: List[Tuple[Any, ...]] = []
+        paragraph_embed_map: Dict[str, str] = {}
+
+        entity_display: Dict[str, str] = {}
+        entity_counts: Dict[str, int] = defaultdict(int)
+        paragraph_entity_mentions: Dict[Tuple[str, str], int] = defaultdict(int)
+        entity_embed_map: Dict[str, str] = {}
+
+        relation_records: Dict[str, Tuple[str, str, str, float, Optional[str], bytes]] = {}
+        paragraph_relation_links: set[Tuple[str, str]] = set()
+
+        for item in rows:
+            is_new_paragraph = item.paragraph_hash not in existing_paragraph_hashes
+
+            start_ts = _safe_float(item.time_meta.get("event_time_start"), 0.0)
+            end_ts = _safe_float(item.time_meta.get("event_time_end"), start_ts)
+            confidence = _safe_float(item.time_meta.get("time_confidence"), 0.95)
+            granularity = _normalize_name(item.time_meta.get("time_granularity")) or "minute"
+
+            if is_new_paragraph:
+                paragraph_records.append(
+                    (
+                        item.paragraph_hash,
+                        item.content,
+                        None,
+                        now_ts,
+                        now_ts,
+                        empty_meta_blob,
+                        item.source,
+                        len(normalize_text(item.content).split()),
+                        None,
+                        start_ts,
+                        end_ts,
+                        granularity,
+                        confidence,
+                        KnowledgeType.NARRATIVE.value,
+                    )
+                )
+
+            if item.paragraph_hash not in self.vector_store:
+                paragraph_embed_map[item.paragraph_hash] = item.content
+
+            for entity in item.entities:
+                name = _normalize_name(entity)
+                if not name:
+                    continue
+                canon = _canonical_name(name)
+                if not canon:
+                    continue
+                entity_hash = compute_hash(canon)
+                entity_display.setdefault(entity_hash, name)
+                if is_new_paragraph:
+                    entity_counts[entity_hash] += 1
+                    paragraph_entity_mentions[(item.paragraph_hash, entity_hash)] += 1
+                if entity_hash not in self.vector_store:
+                    entity_embed_map.setdefault(entity_hash, name)
+
+            for subject, predicate, obj in item.relations:
+                s = _normalize_name(subject)
+                p = _normalize_name(predicate)
+                o = _normalize_name(obj)
+                if not (s and p and o):
+                    continue
+
+                s_canon = _canonical_name(s)
+                p_canon = _canonical_name(p)
+                o_canon = _canonical_name(o)
+                relation_hash = compute_hash(f"{s_canon}|{p_canon}|{o_canon}")
+
+                if is_new_paragraph:
+                    relation_records.setdefault(
+                        relation_hash,
+                        (s, p, o, 1.0, item.paragraph_hash, empty_meta_blob),
+                    )
+                    paragraph_relation_links.add((item.paragraph_hash, relation_hash))
+
+                for relation_entity in (s, o):
+                    e_canon = _canonical_name(relation_entity)
+                    if not e_canon:
+                        continue
+                    e_hash = compute_hash(e_canon)
+                    entity_display.setdefault(e_hash, relation_entity)
+                    if is_new_paragraph:
+                        entity_counts[e_hash] += 1
+                        paragraph_entity_mentions[(item.paragraph_hash, e_hash)] += 1
+                    if e_hash not in self.vector_store:
+                        entity_embed_map.setdefault(e_hash, relation_entity)
+
+        try:
+            cursor.execute("BEGIN")
+
+            if paragraph_records:
+                cursor.executemany(
+                    """
+                    INSERT OR IGNORE INTO paragraphs
+                    (
+                        hash, content, vector_index, created_at, updated_at, metadata, source, word_count,
+                        event_time, event_time_start, event_time_end, time_granularity, time_confidence, knowledge_type
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    paragraph_records,
+                )
+
+            if entity_counts:
+                entity_rows = [
+                    (
+                        entity_hash,
+                        entity_display[entity_hash],
+                        None,
+                        int(count),
+                        now_ts,
+                        empty_meta_blob,
+                    )
+                    for entity_hash, count in entity_counts.items()
+                ]
+                try:
+                    cursor.executemany(
+                        """
+                        INSERT INTO entities
+                        (hash, name, vector_index, appearance_count, created_at, metadata)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(hash) DO UPDATE SET
+                            appearance_count = entities.appearance_count + excluded.appearance_count
+                        """,
+                        entity_rows,
+                    )
+                except sqlite3.OperationalError:
+                    cursor.executemany(
+                        """
+                        INSERT OR IGNORE INTO entities
+                        (hash, name, vector_index, appearance_count, created_at, metadata)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        entity_rows,
+                    )
+                    cursor.executemany(
+                        "UPDATE entities SET appearance_count = appearance_count + ? WHERE hash = ?",
+                        [(int(count), entity_hash) for entity_hash, count in entity_counts.items()],
+                    )
+
+            if paragraph_entity_mentions:
+                pe_rows = [
+                    (paragraph_hash, entity_hash, int(mentions))
+                    for (paragraph_hash, entity_hash), mentions in paragraph_entity_mentions.items()
+                ]
+                try:
+                    cursor.executemany(
+                        """
+                        INSERT INTO paragraph_entities
+                        (paragraph_hash, entity_hash, mention_count)
+                        VALUES (?, ?, ?)
+                        ON CONFLICT(paragraph_hash, entity_hash) DO UPDATE SET
+                            mention_count = paragraph_entities.mention_count + excluded.mention_count
+                        """,
+                        pe_rows,
+                    )
+                except sqlite3.OperationalError:
+                    cursor.executemany(
+                        """
+                        INSERT OR IGNORE INTO paragraph_entities
+                        (paragraph_hash, entity_hash, mention_count)
+                        VALUES (?, ?, ?)
+                        """,
+                        pe_rows,
+                    )
+                    cursor.executemany(
+                        """
+                        UPDATE paragraph_entities
+                        SET mention_count = mention_count + ?
+                        WHERE paragraph_hash = ? AND entity_hash = ?
+                        """,
+                        [(m, p, e) for (p, e, m) in pe_rows],
+                    )
+
+            if relation_records:
+                relation_rows = [
+                    (
+                        relation_hash,
+                        rel[0],
+                        rel[1],
+                        rel[2],
+                        None,
+                        rel[3],
+                        now_ts,
+                        rel[4],
+                        rel[5],
+                    )
+                    for relation_hash, rel in relation_records.items()
+                ]
+                cursor.executemany(
+                    """
+                    INSERT OR IGNORE INTO relations
+                    (hash, subject, predicate, object, vector_index, confidence, created_at, source_paragraph, metadata)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    relation_rows,
+                )
+
+            if paragraph_relation_links:
+                pr_rows = [(p_hash, r_hash) for p_hash, r_hash in paragraph_relation_links]
+                cursor.executemany(
+                    """
+                    INSERT OR IGNORE INTO paragraph_relations
+                    (paragraph_hash, relation_hash)
+                    VALUES (?, ?)
+                    """,
+                    pr_rows,
+                )
+
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+        self.stats["relations_written"] += len(relation_records)
+
+        if relation_records:
+            edge_pairs = []
+            relation_hashes = []
+            for relation_hash, rel in relation_records.items():
+                edge_pairs.append((rel[0], rel[2]))
+                relation_hashes.append(relation_hash)
+
+            with self.graph_store.batch_update():
+                self.graph_store.add_edges(edge_pairs, relation_hashes=relation_hashes)
+            self.stats["graph_edges_written"] += len(edge_pairs)
+
+        para_added = await self._embed_and_add_vectors(
+            id_to_text=paragraph_embed_map,
+            batch_size=max(1, int(self.args.embed_batch_size)),
+            workers=self.embed_workers,
+        )
+        ent_added = await self._embed_and_add_vectors(
+            id_to_text=entity_embed_map,
+            batch_size=max(1, int(self.args.entity_embed_batch_size)),
+            workers=self.embed_workers,
+        )
+        self.stats["paragraph_vectors_added"] += para_added
+        self.stats["entity_vectors_added"] += ent_added
+
+        self.vector_store.save()
+        self.graph_store.save()
+
+        self.stats["windows_committed"] += 1
+        self._flush_state(last_seen_id)
+
+    async def _embed_and_add_vectors(
+        self,
+        id_to_text: Dict[str, str],
+        batch_size: int,
+        workers: int,
+    ) -> int:
+        if not id_to_text:
+            return 0
+        if self.embedding_manager is None:
+            raise MigrationError("embedding_manager 未初始化，无法写入向量")
+
+        ids = []
+        texts = []
+        for hash_id, text in id_to_text.items():
+            if hash_id in self.vector_store:
+                continue
+            ids.append(hash_id)
+            texts.append(text)
+
+        if not ids:
+            return 0
+
+        total_added = 0
+        chunk_size = max(1, int(batch_size))
+        for i in range(0, len(ids), chunk_size):
+            chunk_ids = ids[i : i + chunk_size]
+            chunk_texts = texts[i : i + chunk_size]
+
+            embeddings = await self.embedding_manager.encode_batch(
+                chunk_texts,
+                batch_size=chunk_size,
+                num_workers=max(1, int(workers)),
+            )
+
+            emb_arr = np.asarray(embeddings, dtype=np.float32)
+            if emb_arr.ndim == 1:
+                emb_arr = emb_arr.reshape(1, -1)
+            if emb_arr.shape[0] != len(chunk_ids):
+                logger.warning(
+                    f"embedding 返回数量异常: expected={len(chunk_ids)}, got={emb_arr.shape[0]}，跳过该批次"
+                )
+                continue
+
+            valid_vectors = []
+            valid_ids = []
+            for idx, vec in enumerate(emb_arr):
+                if vec.ndim != 1:
+                    continue
+                if vec.shape[0] != self.vector_store.dimension:
+                    logger.warning(
+                        f"向量维度不匹配，跳过: id={chunk_ids[idx]}, got={vec.shape[0]}, expected={self.vector_store.dimension}"
+                    )
+                    continue
+                if not np.all(np.isfinite(vec)):
+                    logger.warning(f"向量含 NaN/Inf，跳过: id={chunk_ids[idx]}")
+                    continue
+                if chunk_ids[idx] in self.vector_store:
+                    continue
+                valid_vectors.append(vec)
+                valid_ids.append(chunk_ids[idx])
+
+            if valid_vectors:
+                batch_vectors = np.stack(valid_vectors).astype(np.float32, copy=False)
+                added = self.vector_store.add(batch_vectors, valid_ids)
+                total_added += int(added)
+
+        return total_added
+
+    async def _verify(self, strict: bool) -> None:
+        if self.selection is None:
+            raise MigrationError("selection 未初始化")
+
+        sample_size = min(2000, max(0, int(self.stats.get("source_matched_total", 0))))
+        self.stats["verify_sample_size"] = sample_size
+
+        if sample_size <= 0:
+            self.stats["verify_passed"] = True
+            return
+
+        sample_rows = self.source_db.sample_rows_for_verify(self.selection, sample_size)
+        para_missing = 0
+        vec_missing = 0
+        rel_missing = 0
+        edge_missing = 0
+
+        for row in sample_rows:
+            try:
+                mapped = self._map_row(row)
+            except Exception:
+                continue
+
+            paragraph = self.metadata_store.get_paragraph(mapped.paragraph_hash)
+            if paragraph is None:
+                para_missing += 1
+            if mapped.paragraph_hash not in self.vector_store:
+                vec_missing += 1
+
+            for s, p, o in mapped.relations:
+                relation_hash = compute_hash(f"{_canonical_name(s)}|{_canonical_name(p)}|{_canonical_name(o)}")
+                relation = self.metadata_store.get_relation(relation_hash)
+                if relation is None:
+                    rel_missing += 1
+                if self.graph_store.get_edge_weight(s, o) <= 0.0:
+                    edge_missing += 1
+
+        self.stats["verify_paragraph_missing"] = para_missing
+        self.stats["verify_vector_missing"] = vec_missing
+        self.stats["verify_relation_missing"] = rel_missing
+        self.stats["verify_edge_missing"] = edge_missing
+
+        verify_passed = all(x == 0 for x in [para_missing, vec_missing, rel_missing, edge_missing])
+        if strict and not verify_passed:
+            self.failed = True
+            self.fail_reason = (
+                "严格校验失败: "
+                f"paragraph_missing={para_missing}, vector_missing={vec_missing}, "
+                f"relation_missing={rel_missing}, edge_missing={edge_missing}"
+            )
+
+        self.stats["verify_passed"] = verify_passed
+
+    def _finalize(self) -> int:
+        elapsed = time.time() - self.started_at
+        self.stats["elapsed_seconds"] = elapsed
+
+        report = {
+            "success": not self.failed,
+            "fail_reason": self.fail_reason,
+            "args": vars(self.args),
+            "source_db": str(self.source_db_path),
+            "target_data_dir": str(self.target_data_dir),
+            "selection": self.selection.fingerprint_payload() if self.selection else {},
+            "filter_fingerprint": self.filter_fingerprint,
+            "source_db_fingerprint": self.source_db_fingerprint,
+            "state_file": str(self.state_file),
+            "bad_rows_file": str(self.bad_rows_file),
+            "stats": dict(self.stats),
+            "timestamp": time.time(),
+        }
+
+        _dump_json_atomic(self.report_file, report)
+
+        if self.failed:
+            self.exit_code = 1
+        elif self.stats.get("bad_rows", 0) > 0:
+            self.exit_code = 2
+        else:
+            self.exit_code = 0
+
+        print("\n=== Migration Report ===")
+        print(f"success: {not self.failed}")
+        if self.fail_reason:
+            print(f"fail_reason: {self.fail_reason}")
+        print(f"elapsed: {elapsed:.2f}s")
+        print(f"source_matched_total: {self.stats['source_matched_total']}")
+        print(f"scanned_rows: {self.stats['scanned_rows']}")
+        print(f"valid_rows: {self.stats['valid_rows']}")
+        print(f"migrated_rows: {self.stats['migrated_rows']}")
+        print(f"skipped_existing_rows: {self.stats['skipped_existing_rows']}")
+        print(f"bad_rows: {self.stats['bad_rows']}")
+        print(f"paragraph_vectors_added: {self.stats['paragraph_vectors_added']}")
+        print(f"entity_vectors_added: {self.stats['entity_vectors_added']}")
+        print(f"relations_written: {self.stats['relations_written']}")
+        print(f"graph_edges_written: {self.stats['graph_edges_written']}")
+        print(f"windows_committed: {self.stats['windows_committed']}")
+        print(f"last_committed_id: {self.stats['last_committed_id']}")
+        print(
+            "verify: "
+            f"sample={self.stats['verify_sample_size']}, "
+            f"paragraph_missing={self.stats['verify_paragraph_missing']}, "
+            f"vector_missing={self.stats['verify_vector_missing']}, "
+            f"relation_missing={self.stats['verify_relation_missing']}, "
+            f"edge_missing={self.stats['verify_edge_missing']}, "
+            f"passed={self.stats['verify_passed']}"
+        )
+        print(f"report_file: {self.report_file}")
+        print("========================\n")
+
+        return self.exit_code
+
+    def _close(self) -> None:
+        try:
+            if self.metadata_store is not None:
+                self.metadata_store.close()
+        except Exception:
+            pass
+        self.source_db.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="迁移 MaiBot chat_history 到 A_memorix（高性能 + 可断点续传 + 可确认筛选）"
+    )
+
+    parser.add_argument("--source-db", default=str(DEFAULT_SOURCE_DB), help="源数据库路径（默认 data/MaiBot.db）")
+    parser.add_argument(
+        "--target-data-dir",
+        default=str(DEFAULT_TARGET_DATA_DIR),
+        help="A_memorix 数据目录（默认 plugins/A_memorix/data）",
+    )
+
+    resume_group = parser.add_mutually_exclusive_group()
+    resume_group.add_argument("--resume", dest="no_resume", action="store_false", help="启用断点续传（默认）")
+    resume_group.add_argument("--no-resume", dest="no_resume", action="store_true", help="禁用断点续传")
+    parser.set_defaults(no_resume=False)
+
+    parser.add_argument("--reset-state", action="store_true", help="清空迁移状态文件后执行")
+    parser.add_argument("--start-id", type=int, default=None, help="从指定 chat_history.id 开始迁移（覆盖断点）")
+    parser.add_argument("--end-id", type=int, default=None, help="迁移到指定 chat_history.id")
+
+    parser.add_argument("--read-batch-size", type=int, default=2000, help="源库分页读取大小（默认 2000）")
+    parser.add_argument("--commit-window-rows", type=int, default=20000, help="每窗口提交行数（默认 20000）")
+    parser.add_argument("--embed-batch-size", type=int, default=256, help="段落 embedding 批次大小（默认 256）")
+    parser.add_argument(
+        "--entity-embed-batch-size",
+        type=int,
+        default=512,
+        help="实体 embedding 批次大小（默认 512）",
+    )
+    parser.add_argument("--embed-workers", type=int, default=None, help="embedding 并发数（默认读取配置）")
+    parser.add_argument("--max-errors", type=int, default=500, help="坏行上限（默认 500）")
+    parser.add_argument("--log-every", type=int, default=5000, help="日志输出步长（默认 5000）")
+
+    parser.add_argument("--dry-run", action="store_true", help="仅预览不写入")
+    parser.add_argument("--verify-only", action="store_true", help="仅执行严格校验")
+
+    parser.add_argument("--time-from", default=None, help="开始时间：YYYY-MM-DD / YYYY/MM/DD / YYYY-MM-DD HH:mm[:ss]")
+    parser.add_argument("--time-to", default=None, help="结束时间：YYYY-MM-DD / YYYY/MM/DD / YYYY-MM-DD HH:mm[:ss]")
+    parser.add_argument("--stream-id", action="append", default=[], help="聊天流 stream_id（可重复）")
+    parser.add_argument("--group-id", action="append", default=[], help="群号（可重复，自动映射 stream_id）")
+    parser.add_argument("--user-id", action="append", default=[], help="用户号（可重复，自动映射 stream_id）")
+    parser.add_argument("--yes", action="store_true", help="跳过交互确认")
+    parser.add_argument("--preview-limit", type=int, default=20, help="预览样本条数（默认 20）")
+
+    return parser
+
+
+async def async_main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    runner = MigrationRunner(args)
+    return await runner.run()
+
+
+def main() -> int:
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    return asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/import.html
+++ b/web/import.html
@@ -1,0 +1,912 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A_Memorix 导入中心</title>
+    <style>
+      :root {
+        --bg: #0b1220;
+        --panel: #111827;
+        --border: #334155;
+        --text: #e2e8f0;
+        --muted: #94a3b8;
+        --pri: #38bdf8;
+        --ok: #10b981;
+        --warn: #f59e0b;
+        --err: #ef4444;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; color: var(--text); font-family: "Segoe UI", "Microsoft YaHei", sans-serif; background: radial-gradient(circle at 0 0, #0f2a4a, transparent 35%), var(--bg); }
+      .page { width: min(1400px, 96vw); margin: 18px auto 28px; }
+      .top { display: flex; gap: 10px; justify-content: space-between; align-items: end; margin-bottom: 12px; }
+      .top-mid { flex: 1; display: flex; justify-content: center; align-items: end; }
+      .title { font-size: 22px; font-weight: 700; }
+      .sub { color: var(--muted); font-size: 12px; }
+      .token { display: flex; gap: 8px; min-width: 360px; }
+      .grid { display: grid; grid-template-columns: 420px 1fr; gap: 12px; }
+      .card { background: rgba(17, 24, 39, 0.92); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+      .hd { padding: 10px 12px; font-size: 13px; color: var(--pri); border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; }
+      .bd { padding: 12px; }
+      .row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 8px; }
+      .row3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-bottom: 8px; }
+      label { display: block; color: var(--muted); font-size: 12px; margin-bottom: 4px; }
+      input, select, textarea, button { font: inherit; }
+      input, select, textarea { width: 100%; border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; background: #0f172a; color: var(--text); }
+      input[type="checkbox"] { width: 16px; height: 16px; padding: 0; border-radius: 4px; accent-color: var(--pri); flex: 0 0 auto; }
+      textarea { min-height: 120px; resize: vertical; }
+      .checkline { display: flex; align-items: center; gap: 8px; color: var(--text); margin-bottom: 8px; line-height: 1.4; }
+      .checkline:last-child { margin-bottom: 0; }
+      .checkgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 14px; margin-bottom: 8px; }
+      .file-pick { display: flex; align-items: center; gap: 8px; min-height: 38px; padding: 4px; border: 1px solid var(--border); border-radius: 8px; background: #0f172a; }
+      .file-pick .tiny { margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .file-pick input[type="file"] { display: none; }
+      .modal-mask { position: fixed; inset: 0; background: rgba(2, 6, 23, 0.72); display: none; align-items: center; justify-content: center; z-index: 120; padding: 20px; }
+      .modal-mask.show { display: flex; }
+      .modal { width: min(980px, 96vw); max-height: 86vh; background: #0b1528; border: 1px solid var(--border); border-radius: 12px; display: flex; flex-direction: column; overflow: hidden; }
+      .modal-hd { display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; border-bottom: 1px solid var(--border); color: var(--pri); }
+      .modal-bd { padding: 12px; overflow: auto; line-height: 1.62; font-size: 14px; }
+      .md h1, .md h2, .md h3 { margin: 14px 0 8px; color: #f8fafc; }
+      .md p { margin: 8px 0; }
+      .md ul { margin: 8px 0 8px 20px; padding: 0; }
+      .md pre { margin: 10px 0; padding: 10px; border: 1px solid var(--border); border-radius: 8px; background: #0f172a; overflow: auto; }
+      .md code { font-family: Consolas, Menlo, Monaco, monospace; font-size: 12px; }
+      .md a { color: #67e8f9; text-decoration: none; }
+      .md a:hover { text-decoration: underline; }
+      .md blockquote { margin: 10px 0; padding: 8px 10px; border-left: 3px solid var(--pri); background: rgba(56, 189, 248, 0.08); color: #cbd5e1; }
+      .tabs { display: flex; gap: 6px; margin-bottom: 8px; flex-wrap: wrap; }
+      .tabs button { flex: 1 1 calc(33.33% - 6px); min-width: 104px; border: 1px solid var(--border); border-radius: 8px; background: #1f2937; color: var(--text); padding: 7px; cursor: pointer; }
+      .tabs button.active { background: linear-gradient(120deg, #0ea5e9, #22d3ee); color: #01243a; font-weight: 700; border: none; }
+      .panel { display: none; }
+      .panel.active { display: block; }
+      .btns { display: flex; gap: 8px; flex-wrap: wrap; }
+      .btn { border: 1px solid var(--border); border-radius: 8px; padding: 7px 10px; background: #1f2937; color: var(--text); cursor: pointer; }
+      .btn.p { background: linear-gradient(120deg, #0ea5e9, #22d3ee); color: #022f4d; border: none; font-weight: 700; }
+      .btn.warn { border-color: #854d0e; color: #fbbf24; }
+      .btn.err { border-color: #7f1d1d; color: #fca5a5; }
+      .tiny { color: var(--muted); font-size: 12px; }
+      .list { max-height: 150px; overflow: auto; border: 1px dashed var(--border); border-radius: 8px; padding: 6px; }
+      .list-item { display: flex; justify-content: space-between; gap: 8px; padding: 5px; border-radius: 7px; }
+      .list-item:hover { background: #1e293b; }
+      .task-list { max-height: 260px; overflow: auto; display: grid; gap: 7px; }
+      .task { border: 1px solid var(--border); border-radius: 8px; padding: 7px; cursor: pointer; background: #0f172a; }
+      .task.active { border-color: var(--pri); }
+      .badge { font-size: 11px; border: 1px solid var(--border); border-radius: 999px; padding: 1px 7px; }
+      .b-run { color: #67e8f9; } .b-q { color: #c4b5fd; } .b-ok { color: #6ee7b7; } .b-err { color: #fca5a5; } .b-cancel { color: #fcd34d; }
+      .bar { height: 7px; border-radius: 999px; background: #334155; overflow: hidden; margin-top: 5px; }
+      .bar > div { height: 100%; background: linear-gradient(120deg, #0ea5e9, #22d3ee); width: 0; }
+      .mgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 7px; margin-top: 8px; }
+      .m { border: 1px solid var(--border); border-radius: 8px; padding: 7px; background: #0f172a; }
+      .m .k { color: var(--muted); font-size: 11px; } .m .v { font-size: 16px; font-weight: 700; margin-top: 3px; }
+      table { width: 100%; border-collapse: collapse; font-size: 12px; }
+      th, td { text-align: left; border-bottom: 1px solid var(--border); padding: 7px 5px; vertical-align: top; }
+      tr.pick { cursor: pointer; } tr.pick.active { background: #10324f; }
+      .foot { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; }
+      #toast { position: fixed; top: 12px; left: 50%; transform: translateX(-50%); background: #111827; border: 1px solid var(--border); border-radius: 8px; padding: 8px 11px; display: none; z-index: 99; }
+      @media (max-width: 1100px) {
+        .grid { grid-template-columns: 1fr; }
+        .token { min-width: 0; width: 100%; }
+        .top { flex-direction: column; align-items: stretch; }
+        .top-mid { justify-content: flex-start; }
+        .mgrid { grid-template-columns: repeat(2, 1fr); }
+        .checkgrid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="toast"></div>
+    <div id="guide-modal" class="modal-mask" role="dialog" aria-modal="true" aria-labelledby="guide-modal-title">
+      <div class="modal">
+        <div class="modal-hd">
+          <div id="guide-modal-title">导入相关文档</div>
+          <button class="btn" id="guide-close" type="button">关闭</button>
+        </div>
+        <div class="tiny" id="guide-meta" style="padding: 8px 12px 0;"></div>
+        <div class="modal-bd md" id="guide-body"></div>
+      </div>
+    </div>
+    <div class="page">
+      <div class="top">
+        <div>
+          <div class="title">A_Memorix 导入中心</div>
+          <div class="sub">可控并发、部分文件导入、粘贴导入、分块级进度</div>
+        </div>
+        <div class="top-mid">
+          <button class="btn" id="guide-open" type="button">阅读导入文档</button>
+        </div>
+        <div class="token">
+          <input id="token-input" type="password" placeholder="可选：X-Memorix-Import-Token" />
+          <button class="btn" id="token-save">保存</button>
+          <button class="btn" id="token-clear">清空</button>
+        </div>
+      </div>
+
+      <div class="grid">
+        <div>
+          <div class="card">
+            <div class="hd">创建导入任务</div>
+            <div class="bd">
+              <div class="tabs">
+                <button id="tab-upload" class="active">上传文件</button>
+                <button id="tab-paste">粘贴导入</button>
+                <button id="tab-raw">本地扫描</button>
+                <button id="tab-openie">LPMM OpenIE</button>
+                <button id="tab-convert">LPMM转换</button>
+                <button id="tab-backfill">时序回填</button>
+                <button id="tab-maibot">MaiBot迁移</button>
+              </div>
+
+              <div class="row3">
+                <div>
+                  <label>文件并发</label>
+                  <input id="file-concurrency" type="number" min="1" max="6" value="2" />
+                </div>
+                <div>
+                  <label>分块并发</label>
+                  <input id="chunk-concurrency" type="number" min="1" max="12" value="4" />
+                </div>
+                <div>
+                  <label>策略覆盖</label>
+                  <select id="strategy-override">
+                    <option value="auto">自动（auto）</option>
+                    <option value="narrative">叙事（narrative）</option>
+                    <option value="factual">事实（factual）</option>
+                    <option value="quote">引用（quote）</option>
+                  </select>
+                </div>
+              </div>
+              <div class="row3">
+                <div>
+                  <label>去重策略</label>
+                  <select id="dedupe-policy">
+                    <option value="content_hash">内容哈希（content_hash）</option>
+                    <option value="manifest">导入清单（manifest）</option>
+                    <option value="none">不去重（none）</option>
+                  </select>
+                </div>
+                <div>
+                  <label>聊天参考时间（chat_reference_time）</label>
+                  <input id="chat-reference-time" placeholder="2026/02/12 10:30" />
+                </div>
+                <div></div>
+              </div>
+              <div class="checkgrid tiny">
+                <label class="checkline">
+                  <input id="llm-enabled" type="checkbox" checked />
+                  <span>启用 LLM 抽取</span>
+                </label>
+                <label class="checkline">
+                  <input id="chat-log" type="checkbox" />
+                  <span>按聊天日志抽取时间（chat_log）</span>
+                </label>
+                <label class="checkline">
+                  <input id="force-reimport" type="checkbox" />
+                  <span>强制重导（force）</span>
+                </label>
+                <label class="checkline">
+                  <input id="clear-manifest" type="checkbox" />
+                  <span>清理导入清单（clear_manifest）</span>
+                </label>
+              </div>
+
+              <div id="panel-upload" class="panel active">
+                <div class="row">
+                  <div>
+                    <label>文本输入模式</label>
+                    <select id="upload-input-mode">
+                      <option value="text">文本（text）</option>
+                      <option value="json">JSON（json）</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label>选择文件 (txt/md/json)</label>
+                    <div class="file-pick">
+                      <button class="btn" id="upload-file-pick" type="button">选择文件</button>
+                      <div class="tiny" id="upload-file-hint">未选择文件</div>
+                      <input id="upload-file-input" type="file" multiple accept=".txt,.md,.json" />
+                    </div>
+                  </div>
+                </div>
+                <div class="tiny" id="upload-count">已选择 0 个文件</div>
+                <div class="list" id="upload-files"></div>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="upload-submit">提交上传任务</button>
+                  <button class="btn" id="upload-clear">清空文件列表</button>
+                </div>
+              </div>
+
+              <div id="panel-paste" class="panel">
+                <div class="row">
+                  <div>
+                    <label>粘贴模式</label>
+                    <select id="paste-input-mode">
+                      <option value="text">文本（text）</option>
+                      <option value="json">JSON（json）</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label>名称（可选）</label>
+                    <input id="paste-name" placeholder="paste_时间戳" />
+                  </div>
+                </div>
+                <label>内容</label>
+                <textarea id="paste-content" placeholder="粘贴 text/json"></textarea>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="paste-submit">提交粘贴任务</button>
+                </div>
+              </div>
+
+              <div id="panel-raw" class="panel">
+                <div class="row">
+                  <div>
+                    <label>路径别名</label>
+                    <select id="raw-alias"></select>
+                  </div>
+                  <div>
+                    <label>相对路径（relative_path）</label>
+                    <input id="raw-relative-path" placeholder="raw 子目录（可选）" />
+                  </div>
+                </div>
+                <div class="row3">
+                  <div>
+                    <label>匹配规则（glob）</label>
+                    <input id="raw-glob" value="*" />
+                  </div>
+                  <div>
+                    <label>输入模式</label>
+                    <select id="raw-input-mode">
+                      <option value="text">文本（text）</option>
+                      <option value="json">JSON（json）</option>
+                    </select>
+                  </div>
+                  <label class="checkline tiny" style="margin-top: 20px;">
+                    <input id="raw-recursive" type="checkbox" checked />
+                    <span>递归扫描</span>
+                  </label>
+                </div>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="raw-submit">提交本地扫描任务</button>
+                </div>
+              </div>
+
+              <div id="panel-openie" class="panel">
+                <div class="row">
+                  <div>
+                    <label>路径别名</label>
+                    <select id="openie-alias"></select>
+                  </div>
+                  <div>
+                    <label>相对路径（relative_path）</label>
+                    <input id="openie-relative-path" placeholder="OpenIE 目录或文件" />
+                  </div>
+                </div>
+                <label class="checkline tiny">
+                  <input id="openie-include-all" type="checkbox" />
+                  <span>找不到 *-openie.json 时回退全部 .json</span>
+                </label>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="openie-submit">提交 OpenIE 任务</button>
+                </div>
+              </div>
+
+              <div id="panel-convert" class="panel">
+                <div class="row">
+                  <div>
+                    <label>输入别名</label>
+                    <select id="convert-alias"></select>
+                  </div>
+                  <div>
+                    <label>输入相对路径（relative_path）</label>
+                    <input id="convert-relative-path" placeholder="LPMM 数据目录" />
+                  </div>
+                </div>
+                <div class="row">
+                  <div>
+                    <label>目标别名</label>
+                    <select id="convert-target-alias"></select>
+                  </div>
+                  <div>
+                    <label>目标相对路径（relative_path）</label>
+                    <input id="convert-target-relative-path" placeholder="可选：目标子目录" />
+                  </div>
+                </div>
+                <div class="row3">
+                  <div>
+                    <label>向量维度（dimension）</label>
+                    <input id="convert-dimension" type="number" min="1" placeholder="默认读取配置" />
+                  </div>
+                  <div>
+                    <label>批大小（batch_size）</label>
+                    <input id="convert-batch-size" type="number" min="1" value="1024" />
+                  </div>
+                  <div></div>
+                </div>
+                <div class="tiny">将执行 staging 转换与切换，请确认输入目录正确。</div>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn warn" id="convert-submit">提交 LPMM 转换任务</button>
+                </div>
+              </div>
+
+              <div id="panel-backfill" class="panel">
+                <div class="row">
+                  <div>
+                    <label>路径别名</label>
+                    <select id="backfill-alias"></select>
+                  </div>
+                  <div>
+                    <label>相对路径（relative_path）</label>
+                    <input id="backfill-relative-path" placeholder="默认插件 data 目录" />
+                  </div>
+                </div>
+                <div class="row3">
+                  <div>
+                    <label>处理上限（limit）</label>
+                    <input id="backfill-limit" type="number" min="1" value="100000" />
+                  </div>
+                  <label class="checkline tiny" style="margin-top: 20px;">
+                    <input id="backfill-dry-run" type="checkbox" />
+                    <span>仅预览（dry-run）</span>
+                  </label>
+                  <label class="checkline tiny" style="margin-top: 20px;">
+                    <input id="backfill-no-created" type="checkbox" />
+                    <span>禁用 created 回退（no-created-fallback）</span>
+                  </label>
+                </div>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="backfill-submit">提交时序回填任务</button>
+                </div>
+              </div>
+
+              <div id="panel-maibot" class="panel">
+                <div class="row">
+                  <div>
+                    <label>源数据库路径</label>
+                    <input id="maibot-source-db" placeholder="data/MaiBot.db" />
+                  </div>
+                  <div>
+                    <label>时间范围（可选）</label>
+                    <input id="maibot-time-from" placeholder="from: YYYY-MM-DD HH:mm" />
+                  </div>
+                </div>
+                <div class="row">
+                  <div>
+                    <label>时间范围（可选）</label>
+                    <input id="maibot-time-to" placeholder="to: YYYY-MM-DD HH:mm" />
+                  </div>
+                  <div>
+                    <label>ID范围（可选）</label>
+                    <input id="maibot-start-id" type="number" min="1" placeholder="start_id" />
+                  </div>
+                </div>
+                <div class="row">
+                  <div>
+                    <label>ID范围（可选）</label>
+                    <input id="maibot-end-id" type="number" min="1" placeholder="end_id" />
+                  </div>
+                  <div>
+                    <label>stream_ids（逗号分隔）</label>
+                    <input id="maibot-stream-ids" placeholder="stream1,stream2" />
+                  </div>
+                </div>
+                <div class="row">
+                  <div>
+                    <label>group_ids（逗号分隔）</label>
+                    <input id="maibot-group-ids" placeholder="123456,234567" />
+                  </div>
+                  <div>
+                    <label>user_ids（逗号分隔）</label>
+                    <input id="maibot-user-ids" placeholder="10001,10002" />
+                  </div>
+                </div>
+                <div class="row3">
+                  <div>
+                    <label>读取批大小（read_batch_size）</label>
+                    <input id="maibot-read-batch-size" type="number" min="1" value="2000" />
+                  </div>
+                  <div>
+                    <label>提交窗口行数（commit_window_rows）</label>
+                    <input id="maibot-commit-window-rows" type="number" min="1" value="20000" />
+                  </div>
+                  <div>
+                    <label>嵌入工作线程（embed_workers）</label>
+                    <input id="maibot-embed-workers" type="number" min="1" placeholder="默认读取配置" />
+                  </div>
+                </div>
+                <div class="checkgrid tiny">
+                  <label class="checkline">
+                    <input id="maibot-no-resume" type="checkbox" />
+                    <span>禁用断点续传（--no-resume）</span>
+                  </label>
+                  <label class="checkline">
+                    <input id="maibot-reset-state" type="checkbox" />
+                    <span>重置迁移状态（--reset-state）</span>
+                  </label>
+                  <label class="checkline">
+                    <input id="maibot-dry-run" type="checkbox" />
+                    <span>仅预览（--dry-run）</span>
+                  </label>
+                  <label class="checkline">
+                    <input id="maibot-verify-only" type="checkbox" />
+                    <span>仅校验（--verify-only）</span>
+                  </label>
+                </div>
+                <div class="btns" style="margin-top: 8px;">
+                  <button class="btn p" id="maibot-submit">提交 MaiBot 迁移任务</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top: 12px;">
+            <div class="hd"><span>任务队列</span><span class="tiny" id="poll-meta">轮询: 1000ms</span></div>
+            <div class="bd">
+              <div class="btns" style="margin-bottom: 9px;">
+                <button class="btn" id="refresh-btn">立即刷新</button>
+                <button class="btn err" id="cancel-btn">取消任务</button>
+                <button class="btn warn" id="retry-btn">重试失败项（分块优先）</button>
+              </div>
+              <div class="tiny">运行中 / 准备中</div>
+              <div class="task-list" id="tasks-running"></div>
+              <div class="tiny" style="margin-top: 8px;">排队中</div>
+              <div class="task-list" id="tasks-queued"></div>
+              <div class="tiny" style="margin-top: 8px;">最近完成</div>
+              <div class="task-list" id="tasks-recent"></div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="card">
+            <div class="hd">任务详情</div>
+            <div class="bd">
+              <div id="task-empty" class="tiny">请选择任务查看详情</div>
+              <div id="task-body" style="display: none;">
+                <div class="row">
+                  <div><div class="tiny">任务 ID</div><div id="d-id" style="font-size: 12px;"></div></div>
+                  <div><div class="tiny">状态 / 步骤</div><div id="d-status"></div></div>
+                </div>
+                <div class="bar"><div id="d-progress"></div></div>
+                <div class="tiny" id="d-progress-text" style="margin-top: 5px;"></div>
+                <div class="mgrid">
+                  <div class="m"><div class="k">总分块</div><div class="v" id="m-total">0</div></div>
+                  <div class="m"><div class="k">完成</div><div class="v" id="m-done">0</div></div>
+                  <div class="m"><div class="k">失败</div><div class="v" id="m-fail">0</div></div>
+                  <div class="m"><div class="k">取消</div><div class="v" id="m-cancel">0</div></div>
+                </div>
+                <div id="d-error" style="color: #fca5a5; margin-top: 6px;"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top: 12px;">
+            <div class="hd">文件级状态</div>
+            <div class="bd">
+              <table>
+                <thead><tr><th>文件</th><th>类型</th><th>状态</th><th>步骤</th><th>进度</th><th>统计</th></tr></thead>
+                <tbody id="files-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top: 12px;">
+            <div class="hd">分块级状态</div>
+            <div class="bd">
+              <table>
+                <thead><tr><th>#</th><th>类型</th><th>状态</th><th>步骤</th><th>预览</th><th>错误</th></tr></thead>
+                <tbody id="chunks-body"></tbody>
+              </table>
+              <div class="foot">
+                <div class="tiny" id="chunk-meta">0 / 0</div>
+                <div class="btns">
+                  <button class="btn" id="chunk-prev">上一页</button>
+                  <button class="btn" id="chunk-next">下一页</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const state = { files: [], tasks: [], task: null, taskId: null, fileId: null, chunkOffset: 0, chunkLimit: 100, chunkTotal: 0, settings: {}, pathAliases: {}, pollMs: 1000, timer: null, pollErrSig: "", pollErrAt: 0 };
+      const $ = (id) => document.getElementById(id);
+      const esc = (s) => String(s ?? "").replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;").replaceAll('"',"&quot;").replaceAll("'","&#39;");
+      const pct = (n) => `${(Math.max(0, Math.min(1, Number(n || 0))) * 100).toFixed(1)}%`;
+      const badgeClass = (s) => ["running","preparing","cancel_requested"].includes(s) ? "b-run" : s==="queued" ? "b-q" : ["completed","completed_with_errors"].includes(s) ? "b-ok" : s==="failed" ? "b-err" : s==="cancelled" ? "b-cancel" : "";
+      const STATUS_ZH = {
+        queued: "排队中",
+        preparing: "准备中",
+        running: "运行中",
+        cancel_requested: "取消中",
+        cancelled: "已取消",
+        completed: "已完成",
+        completed_with_errors: "完成（有错误）",
+        failed: "失败",
+        splitting: "分块中",
+        extracting: "抽取中",
+        writing: "写入中",
+        saving: "保存中",
+      };
+      const STEP_ZH = {
+        queued: "排队中",
+        scanning: "扫描中",
+        preparing: "准备中",
+        splitting: "分块中",
+        extracting: "抽取中",
+        writing: "写入中",
+        saving: "保存中",
+        converting: "转换中",
+        verifying: "校验中",
+        switching: "切换中",
+        backfilling: "回填中",
+        cancel_requested: "取消中",
+        cancelled: "已取消",
+        completed: "已完成",
+        completed_with_errors: "完成（有错误）",
+        failed: "失败",
+      };
+      const STRATEGY_ZH = {
+        auto: "自动",
+        narrative: "叙事",
+        factual: "事实",
+        quote: "引用",
+        json: "JSON",
+        text: "文本",
+      };
+      const TASK_KIND_ZH = {
+        upload: "上传文件",
+        paste: "粘贴导入",
+        raw_scan: "本地扫描",
+        lpmm_openie: "LPMM OpenIE",
+        lpmm_convert: "LPMM 转换",
+        temporal_backfill: "时序回填",
+        maibot_migration: "MaiBot 迁移",
+      };
+      const SCHEMA_ZH = {
+        web_json: "Web JSON",
+        script_json: "脚本 JSON",
+        lpmm_openie: "LPMM OpenIE",
+        plain_text: "纯文本",
+      };
+      const SOURCE_ZH = {
+        upload: "上传文件",
+        paste: "粘贴导入",
+        raw_scan: "本地扫描",
+        lpmm_openie: "LPMM OpenIE",
+        lpmm_convert: "LPMM 转换",
+        temporal_backfill: "时序回填",
+        maibot_migration: "MaiBot 迁移",
+      };
+      const chunkTypeZh = (v) => STRATEGY_ZH[String(v || "").trim()] || String(v || "-");
+      const statusZh = (v) => STATUS_ZH[String(v || "").trim()] || String(v || "-");
+      const stepZh = (v) => STEP_ZH[String(v || "").trim()] || String(v || "-");
+      const taskKindZh = (v) => TASK_KIND_ZH[String(v || "").trim()] || String(v || "-");
+      const schemaZh = (v) => SCHEMA_ZH[String(v || "").trim()] || String(v || "-");
+      const sourceZh = (v) => SOURCE_ZH[String(v || "").trim()] || String(v || "-");
+
+      function toast(msg) { const t=$("toast"); t.textContent=msg; t.style.display="block"; clearTimeout(window._tt); window._tt=setTimeout(()=>t.style.display="none",2200); }
+      function token(){ return String(localStorage.getItem("memorix_import_token") || "").trim(); }
+      function headers(isJson=true){ const h={}; if(isJson) h["Content-Type"]="application/json"; const tk=token(); if(tk) h["X-Memorix-Import-Token"]=tk; return h; }
+      async function req(path,opt={}){ const r=await fetch(path,opt); let b=null; try{b=await r.json();}catch{} if(!r.ok) throw new Error(typeof b?.detail==="string"?b.detail:`请求失败（HTTP ${r.status}）`); return b||{}; }
+      const parseCsvList = (v) => String(v || "").split(",").map(x => x.trim()).filter(Boolean);
+      const numOrNull = (v) => { const t = String(v ?? "").trim(); if(!t) return null; const n = Number(t); return Number.isFinite(n) ? n : null; };
+
+      function renderGuideMarkdown(md){
+        const src = String(md || "").replace(/\r\n/g, "\n");
+        const codeBlocks = [];
+        let text = src.replace(/```([\s\S]*?)```/g, (_, code) => {
+          const idx = codeBlocks.length;
+          codeBlocks.push(`<pre><code>${esc(code).trim()}</code></pre>`);
+          return `@@CODE_${idx}@@`;
+        });
+        text = esc(text);
+        text = text.replace(/^###\s+(.+)$/gm, "<h3>$1</h3>");
+        text = text.replace(/^##\s+(.+)$/gm, "<h2>$1</h2>");
+        text = text.replace(/^#\s+(.+)$/gm, "<h1>$1</h1>");
+        text = text.replace(/^>\s+(.+)$/gm, "<blockquote>$1</blockquote>");
+        text = text.replace(/^\s*[-*]\s+(.+)$/gm, "<li>$1</li>");
+        text = text.replace(/(?:<li>[\s\S]*?<\/li>\s*)+/g, (m) => `<ul>${m}</ul>`);
+        text = text.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+        text = text.replace(/`([^`]+)`/g, "<code>$1</code>");
+        text = text.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+        text = text.split(/\n{2,}/).map((blk) => {
+          const b = blk.trim();
+          if(!b) return "";
+          if(/^@@CODE_\d+@@$/.test(b)) return b;
+          if(/^<(h1|h2|h3|ul|pre|blockquote)/.test(b)) return b;
+          return `<p>${b.replace(/\n/g, "<br/>")}</p>`;
+        }).join("");
+        text = text.replace(/@@CODE_(\d+)@@/g, (_, i) => codeBlocks[Number(i)] || "");
+        return text || `<p class="tiny">文档为空</p>`;
+      }
+
+      async function openGuideModal(){
+        $("guide-modal").classList.add("show");
+        $("guide-meta").textContent = "";
+        $("guide-body").innerHTML = `<p class="tiny">正在加载文档...</p>`;
+        try{
+          const d = await req("/api/import/guide", { headers: headers(false) });
+          const srcText = d.source === "remote" ? "远程" : "本地";
+          const sourceDesc = d.source === "remote" ? (d.url || "") : (d.path || "");
+          $("guide-meta").textContent = `来源: ${srcText}${sourceDesc ? ` | ${sourceDesc}` : ""}`;
+          $("guide-body").innerHTML = renderGuideMarkdown(d.content || "");
+        }catch(e){
+          $("guide-meta").textContent = "";
+          $("guide-body").innerHTML = `<p style="color:#fca5a5;">文档加载失败: ${esc(e.message || "")}</p>`;
+        }
+      }
+
+      function closeGuideModal(){ $("guide-modal").classList.remove("show"); }
+
+      function commonParams(){
+        const mf=Number(state.settings.max_file_concurrency || 6), mc=Number(state.settings.max_chunk_concurrency || 12);
+        const fc=Math.max(1,Math.min(mf,Number($("file-concurrency").value||2)));
+        const cc=Math.max(1,Math.min(mc,Number($("chunk-concurrency").value||4)));
+        $("file-concurrency").value=fc; $("chunk-concurrency").value=cc;
+        return {
+          file_concurrency: fc,
+          chunk_concurrency: cc,
+          llm_enabled: $("llm-enabled").checked,
+          strategy_override: $("strategy-override").value,
+          dedupe_policy: $("dedupe-policy").value,
+          chat_log: !!$("chat-log").checked,
+          chat_reference_time: ($("chat-reference-time").value || "").trim() || null,
+          force: !!$("force-reimport").checked,
+          clear_manifest: !!$("clear-manifest").checked,
+        };
+      }
+
+      function renderUploadFiles(){
+        $("upload-count").textContent=`已选择 ${state.files.length} 个文件`;
+        $("upload-file-hint").textContent = state.files.length ? `已选择 ${state.files.length} 个文件` : "未选择文件";
+        $("upload-files").innerHTML = state.files.length ? state.files.map((f,i)=>`<div class="list-item"><div><div>${esc(f.name)}</div><div class="tiny">${(f.size/1024).toFixed(1)} KB</div></div><button class="btn" data-rm="${i}">移除</button></div>`).join("") : `<div class="tiny">暂无文件</div>`;
+      }
+
+      function populateAliasSelects(){
+        const aliases = state.pathAliases || {};
+        const keys = Object.keys(aliases);
+        const html = keys.length ? keys.map((k)=>`<option value="${esc(k)}">${esc(k)} (${esc(aliases[k])})</option>`).join("") : `<option value="">(无可用路径别名)</option>`;
+        ["raw-alias","openie-alias","convert-alias","convert-target-alias","backfill-alias"].forEach((id)=>{
+          const el=$(id); if(!el) return;
+          const old=el.value;
+          el.innerHTML=html;
+          if(old && keys.includes(old)) el.value=old;
+          if(!el.value){
+            if(id==="raw-alias" && keys.includes("raw")) el.value="raw";
+            else if(id==="openie-alias" && keys.includes("lpmm")) el.value="lpmm";
+            else if(id==="convert-alias" && keys.includes("lpmm")) el.value="lpmm";
+            else if(id==="convert-target-alias" && keys.includes("plugin_data")) el.value="plugin_data";
+            else if(id==="backfill-alias" && keys.includes("plugin_data")) el.value="plugin_data";
+          }
+        });
+      }
+
+      function renderTaskLists(){
+        const g={run:[],q:[],r:[]};
+        for(const t of state.tasks){ if(["running","preparing","cancel_requested"].includes(t.status)) g.run.push(t); else if(t.status==="queued") g.q.push(t); else g.r.push(t); }
+        const render = (list) => list.length ? list.map(t=>`<div class="task ${state.taskId===t.task_id?"active":""}" data-tid="${t.task_id}"><div style="display:flex;justify-content:space-between;gap:8px;"><span>${esc(t.task_id.slice(0,12))}</span><span class="badge ${badgeClass(t.status)}">${esc(statusZh(t.status))}</span></div><div class="tiny">来源=${esc(sourceZh(t.source))} | 步骤=${esc(stepZh(t.current_step||"-"))}</div><div class="bar"><div style="width:${pct(t.progress)}"></div></div><div class="tiny">${pct(t.progress)} | ${t.done_chunks}/${t.total_chunks}</div></div>`).join("") : `<div class="tiny">暂无任务</div>`;
+        $("tasks-running").innerHTML=render(g.run); $("tasks-queued").innerHTML=render(g.q); $("tasks-recent").innerHTML=render(g.r);
+      }
+
+      async function loadTasks(){
+        const d=await req("/api/import/tasks?limit=80",{headers:headers(false)});
+        state.tasks=Array.isArray(d.items)?d.items:[]; state.settings=d.settings||state.settings||{};
+        state.pathAliases = state.settings.path_aliases || state.pathAliases || {};
+        const p=Number(state.settings.poll_interval_ms||1000); if(p!==state.pollMs){ state.pollMs=Math.max(200,p); restartPoll(); }
+        $("poll-meta").textContent=`轮询: ${state.pollMs}ms`;
+        if(state.settings.default_file_concurrency && !$("file-concurrency").dataset.touched) $("file-concurrency").value=state.settings.default_file_concurrency;
+        if(state.settings.default_chunk_concurrency && !$("chunk-concurrency").dataset.touched) $("chunk-concurrency").value=state.settings.default_chunk_concurrency;
+        if(state.settings.max_file_concurrency) $("file-concurrency").max=state.settings.max_file_concurrency;
+        if(state.settings.max_chunk_concurrency) $("chunk-concurrency").max=state.settings.max_chunk_concurrency;
+        if(state.settings.maibot_source_db_default && !$("maibot-source-db").dataset.touched) $("maibot-source-db").value=state.settings.maibot_source_db_default;
+        populateAliasSelects();
+        if(!state.taskId && state.tasks.length) state.taskId=state.tasks[0].task_id;
+        if(state.taskId && !state.tasks.some(t=>t.task_id===state.taskId)){ state.taskId=state.tasks.length?state.tasks[0].task_id:null; state.fileId=null; }
+        renderTaskLists();
+      }
+
+      function renderTaskDetail(task){
+        if(!task){ $("task-empty").style.display="block"; $("task-body").style.display="none"; $("files-body").innerHTML=`<tr><td colspan="6" class="tiny">暂无数据</td></tr>`; $("chunks-body").innerHTML=`<tr><td colspan="6" class="tiny">暂无数据</td></tr>`; $("chunk-meta").textContent="0 / 0"; return; }
+        $("task-empty").style.display="none"; $("task-body").style.display="block";
+        $("d-id").textContent=task.task_id; $("d-status").innerHTML=`<span class="badge ${badgeClass(task.status)}">${esc(statusZh(task.status))}</span> <span class="tiny">步骤=${esc(stepZh(task.current_step||"-"))}</span>`;
+        $("d-progress").style.width=pct(task.progress); $("d-progress-text").textContent=`${pct(task.progress)} | 完成=${task.done_chunks} 失败=${task.failed_chunks} 取消=${task.cancelled_chunks} 总计=${task.total_chunks}`;
+        $("m-total").textContent=task.total_chunks||0; $("m-done").textContent=task.done_chunks||0; $("m-fail").textContent=task.failed_chunks||0; $("m-cancel").textContent=task.cancelled_chunks||0;
+        const extraMeta = [];
+        if(task.schema_detected) extraMeta.push(`识别模式=${schemaZh(task.schema_detected)}`);
+        if(task.task_kind) extraMeta.push(`任务类型=${taskKindZh(task.task_kind)}`);
+        if(task.retry_parent_task_id) extraMeta.push(`父任务=${task.retry_parent_task_id}`);
+        if(task.retry_summary && Object.keys(task.retry_summary).length) extraMeta.push(`重试摘要=${JSON.stringify(task.retry_summary)}`);
+        if(task.artifact_paths && Object.keys(task.artifact_paths).length) extraMeta.push(`产物=${JSON.stringify(task.artifact_paths)}`);
+        if(task.rollback_info && Object.keys(task.rollback_info).length) extraMeta.push(`回滚=${JSON.stringify(task.rollback_info)}`);
+        const errText = task.error ? `错误: ${task.error}` : "";
+        $("d-error").textContent = [errText, ...extraMeta].filter(Boolean).join(" | ");
+        const files=Array.isArray(task.files)?task.files:[];
+        $("files-body").innerHTML=files.length?files.map(f=>`<tr class="pick ${state.fileId===f.file_id?"active":""}" data-fid="${f.file_id}"><td>${esc(f.name)}</td><td>${esc(chunkTypeZh(f.detected_strategy_type||"-"))}</td><td><span class="badge ${badgeClass(f.status)}">${esc(statusZh(f.status))}</span></td><td>${esc(stepZh(f.current_step||"-"))}</td><td><div class="bar"><div style="width:${pct(f.progress)}"></div></div><div class="tiny">${pct(f.progress)}</div></td><td>${f.done_chunks}/${f.total_chunks} (失败:${f.failed_chunks} 取消:${f.cancelled_chunks})</td></tr>`).join(""):`<tr><td colspan="6" class="tiny">暂无文件</td></tr>`;
+      }
+
+      async function loadTaskDetail(){
+        if(!state.taskId){ renderTaskDetail(null); return; }
+        const d=await req(`/api/import/tasks/${encodeURIComponent(state.taskId)}`,{headers:headers(false)});
+        state.task=d.task||null; const files=Array.isArray(state.task?.files)?state.task.files:[]; if(!state.fileId || !files.some(x=>x.file_id===state.fileId)){ state.fileId=files.length?files[0].file_id:null; state.chunkOffset=0; }
+        renderTaskDetail(state.task);
+      }
+
+      async function loadChunks(){
+        if(!state.taskId || !state.fileId){ $("chunks-body").innerHTML=`<tr><td colspan="6" class="tiny">请选择文件</td></tr>`; $("chunk-meta").textContent="0 / 0"; return; }
+        const d=await req(`/api/import/tasks/${encodeURIComponent(state.taskId)}/files/${encodeURIComponent(state.fileId)}/chunks?offset=${state.chunkOffset}&limit=${state.chunkLimit}`,{headers:headers(false)});
+        const it=Array.isArray(d.items)?d.items:[]; state.chunkTotal=Number(d.total||0);
+        $("chunks-body").innerHTML=it.length?it.map(c=>`<tr><td>${c.index}</td><td>${esc(chunkTypeZh(c.chunk_type||"-"))}</td><td><span class="badge ${badgeClass(c.status)}">${esc(statusZh(c.status))}</span></td><td>${esc(stepZh(c.step||"-"))}</td><td title="${esc(c.content_preview||"")}">${esc(c.content_preview||"").slice(0,90)}</td><td style="color:#fca5a5">${esc(c.error||"")}</td></tr>`).join(""):`<tr><td colspan="6" class="tiny">暂无分块</td></tr>`;
+        const from=state.chunkTotal?state.chunkOffset+1:0, to=Math.min(state.chunkOffset+state.chunkLimit,state.chunkTotal); $("chunk-meta").textContent=`${from}-${to} / ${state.chunkTotal}`;
+      }
+
+      async function createUploadTask(){
+        if(!state.files.length){ toast("请先选择文件"); return; }
+        const fd=new FormData(); state.files.forEach(f=>fd.append("files[]",f,f.name)); fd.append("payload",JSON.stringify({ ...commonParams(), input_mode:$("upload-input-mode").value }));
+        const d=await req("/api/import/tasks/upload",{method:"POST",headers:headers(false),body:fd}); if(d?.task?.task_id) state.taskId=d.task.task_id; state.files=[]; renderUploadFiles(); toast("上传任务已创建");
+      }
+
+      async function createPasteTask(){
+        const content=$("paste-content").value||""; if(!content.trim()){ toast("粘贴内容不能为空"); return; }
+        const d=await req("/api/import/tasks/paste",{method:"POST",headers:headers(true),body:JSON.stringify({ ...commonParams(), input_mode:$("paste-input-mode").value, content, name:$("paste-name").value||"" })});
+        if(d?.task?.task_id) state.taskId=d.task.task_id; toast("粘贴任务已创建");
+      }
+
+      async function createRawScanTask(){
+        const payload = {
+          ...commonParams(),
+          alias: $("raw-alias").value,
+          relative_path: ($("raw-relative-path").value || "").trim(),
+          glob: ($("raw-glob").value || "*").trim() || "*",
+          recursive: !!$("raw-recursive").checked,
+          input_mode: $("raw-input-mode").value,
+        };
+        const d=await req("/api/import/tasks/raw_scan",{method:"POST",headers:headers(true),body:JSON.stringify(payload)});
+        if(d?.task?.task_id) state.taskId=d.task.task_id;
+        toast("本地扫描任务已创建");
+      }
+
+      async function createLpmmOpenieTask(){
+        const payload = {
+          ...commonParams(),
+          alias: $("openie-alias").value,
+          relative_path: ($("openie-relative-path").value || "").trim(),
+          include_all_json: !!$("openie-include-all").checked,
+        };
+        const d=await req("/api/import/tasks/lpmm_openie",{method:"POST",headers:headers(true),body:JSON.stringify(payload)});
+        if(d?.task?.task_id) state.taskId=d.task.task_id;
+        toast("LPMM OpenIE 任务已创建");
+      }
+
+      async function createLpmmConvertTask(){
+        if(!confirm("该任务会执行 staging 转换并切换 vectors/graph/metadata，是否继续？")) return;
+        const payload = {
+          alias: $("convert-alias").value,
+          relative_path: ($("convert-relative-path").value || "").trim(),
+          target_alias: $("convert-target-alias").value,
+          target_relative_path: ($("convert-target-relative-path").value || "").trim(),
+          dimension: numOrNull($("convert-dimension").value),
+          batch_size: numOrNull($("convert-batch-size").value),
+        };
+        const d=await req("/api/import/tasks/lpmm_convert",{method:"POST",headers:headers(true),body:JSON.stringify(payload)});
+        if(d?.task?.task_id) state.taskId=d.task.task_id;
+        toast("LPMM 转换任务已创建");
+      }
+
+      async function createTemporalBackfillTask(){
+        const payload = {
+          alias: $("backfill-alias").value,
+          relative_path: ($("backfill-relative-path").value || "").trim(),
+          dry_run: !!$("backfill-dry-run").checked,
+          no_created_fallback: !!$("backfill-no-created").checked,
+          limit: numOrNull($("backfill-limit").value),
+        };
+        const d=await req("/api/import/tasks/temporal_backfill",{method:"POST",headers:headers(true),body:JSON.stringify(payload)});
+        if(d?.task?.task_id) state.taskId=d.task.task_id;
+        toast("时序回填任务已创建");
+      }
+
+      async function createMaibotMigrationTask(){
+        const payload = {
+          source_db: ($("maibot-source-db").value || "").trim() || null,
+          time_from: ($("maibot-time-from").value || "").trim() || null,
+          time_to: ($("maibot-time-to").value || "").trim() || null,
+          stream_ids: parseCsvList($("maibot-stream-ids").value),
+          group_ids: parseCsvList($("maibot-group-ids").value),
+          user_ids: parseCsvList($("maibot-user-ids").value),
+          start_id: numOrNull($("maibot-start-id").value),
+          end_id: numOrNull($("maibot-end-id").value),
+          read_batch_size: numOrNull($("maibot-read-batch-size").value),
+          commit_window_rows: numOrNull($("maibot-commit-window-rows").value),
+          embed_workers: numOrNull($("maibot-embed-workers").value),
+          no_resume: !!$("maibot-no-resume").checked,
+          reset_state: !!$("maibot-reset-state").checked,
+          dry_run: !!$("maibot-dry-run").checked,
+          verify_only: !!$("maibot-verify-only").checked,
+        };
+        const d = await req("/api/import/tasks/maibot_migration", {
+          method: "POST",
+          headers: headers(true),
+          body: JSON.stringify(payload),
+        });
+        if(d?.task?.task_id) state.taskId = d.task.task_id;
+        toast("MaiBot 迁移任务已创建");
+      }
+
+      async function cancelTask(){ if(!state.taskId){ toast("请先选择任务"); return; } await req(`/api/import/tasks/${encodeURIComponent(state.taskId)}/cancel`,{method:"POST",headers:headers(false)}); toast("已请求取消"); }
+      async function retryTask(){
+        if(!state.taskId){ toast("请先选择任务"); return; }
+        const d=await req(`/api/import/tasks/${encodeURIComponent(state.taskId)}/retry_failed`,{method:"POST",headers:headers(true),body:JSON.stringify(commonParams())});
+        if(d?.task?.task_id) state.taskId=d.task.task_id;
+        const rs = d?.retry_summary || d?.task?.retry_summary || {};
+        const chunkFiles = Number(rs?.chunk_retry_files || 0);
+        const chunkCount = Number(rs?.chunk_retry_chunks || 0);
+        const fileFallback = Number(rs?.file_fallback_files || 0);
+        toast(`重试任务已创建：分块重试 ${chunkFiles} 文件/${chunkCount} 分块，文件回退 ${fileFallback} 文件`);
+      }
+
+      async function poll(){
+        try{
+          await loadTasks(); await loadTaskDetail(); await loadChunks();
+          state.pollErrSig = "";
+        }catch(e){
+          const sig = String(e.message || "请求失败");
+          const now = Date.now();
+          if(sig !== state.pollErrSig || now - state.pollErrAt > 5000){
+            toast(`请求失败: ${sig}`);
+            state.pollErrSig = sig;
+            state.pollErrAt = now;
+          }
+        }
+      }
+      function restartPoll(){ if(state.timer) clearInterval(state.timer); state.timer=setInterval(poll,state.pollMs); }
+
+      function bind(){
+        $("token-input").value=token();
+        $("token-save").onclick=()=>{ localStorage.setItem("memorix_import_token",String($("token-input").value||"").trim()); toast("Token 已保存"); };
+        $("token-clear").onclick=()=>{ localStorage.removeItem("memorix_import_token"); $("token-input").value=""; toast("Token 已清空"); };
+        $("guide-open").onclick=()=>openGuideModal();
+        $("guide-close").onclick=()=>closeGuideModal();
+        $("guide-modal").onclick=(e)=>{ if(e.target === $("guide-modal")) closeGuideModal(); };
+        window.addEventListener("keydown",(e)=>{ if(e.key==="Escape" && $("guide-modal").classList.contains("show")) closeGuideModal(); });
+        const tabs = ["upload","paste","raw","openie","convert","backfill","maibot"];
+        const activateTab = (name) => {
+          tabs.forEach((t)=>{
+            const tab = $(`tab-${t}`);
+            const panel = $(`panel-${t}`);
+            if(tab) tab.classList.toggle("active", t===name);
+            if(panel) panel.classList.toggle("active", t===name);
+          });
+          if(["raw","openie"].includes(name)){
+            $("dedupe-policy").value = "manifest";
+          }else if(["upload","paste"].includes(name)){
+            $("dedupe-policy").value = "content_hash";
+          }
+        };
+        tabs.forEach((t)=>{ const tab = $(`tab-${t}`); if(tab) tab.onclick=()=>activateTab(t); });
+        $("file-concurrency").oninput=(e)=>e.target.dataset.touched="1"; $("chunk-concurrency").oninput=(e)=>e.target.dataset.touched="1";
+        $("maibot-source-db").oninput=(e)=>e.target.dataset.touched="1";
+        $("upload-file-pick").onclick=()=>$("upload-file-input").click();
+        $("upload-file-input").onchange=(e)=>{ Array.from(e.target.files||[]).forEach(f=>state.files.push(f)); e.target.value=""; renderUploadFiles(); };
+        $("upload-files").onclick=(e)=>{ const i=e.target?.dataset?.rm; if(i===undefined) return; state.files.splice(Number(i),1); renderUploadFiles(); };
+        $("upload-clear").onclick=()=>{ state.files=[]; renderUploadFiles(); };
+        $("upload-submit").onclick=async()=>{ try{ await createUploadTask(); await poll(); }catch(e){ toast(`上传失败: ${e.message}`); } };
+        $("paste-submit").onclick=async()=>{ try{ await createPasteTask(); await poll(); }catch(e){ toast(`粘贴失败: ${e.message}`); } };
+        $("raw-submit").onclick=async()=>{ try{ await createRawScanTask(); await poll(); }catch(e){ toast(`本地扫描失败: ${e.message}`); } };
+        $("openie-submit").onclick=async()=>{ try{ await createLpmmOpenieTask(); await poll(); }catch(e){ toast(`OpenIE 导入失败: ${e.message}`); } };
+        $("convert-submit").onclick=async()=>{ try{ await createLpmmConvertTask(); await poll(); }catch(e){ toast(`LPMM 转换失败: ${e.message}`); } };
+        $("backfill-submit").onclick=async()=>{ try{ await createTemporalBackfillTask(); await poll(); }catch(e){ toast(`回填任务失败: ${e.message}`); } };
+        $("maibot-submit").onclick=async()=>{ try{ await createMaibotMigrationTask(); await poll(); }catch(e){ toast(`迁移任务创建失败: ${e.message}`); } };
+        $("refresh-btn").onclick=async()=>{ await poll(); toast("已刷新"); };
+        $("cancel-btn").onclick=async()=>{ try{ await cancelTask(); await poll(); }catch(e){ toast(`取消失败: ${e.message}`); } };
+        $("retry-btn").onclick=async()=>{ try{ await retryTask(); await poll(); }catch(e){ toast(`重试失败: ${e.message}`); } };
+        ["tasks-running","tasks-queued","tasks-recent"].forEach(id=>$(id).onclick=async(e)=>{ const n=e.target.closest("[data-tid]"); if(!n) return; state.taskId=n.dataset.tid; state.fileId=null; state.chunkOffset=0; renderTaskLists(); try{ await loadTaskDetail(); await loadChunks(); }catch(err){ toast(`加载失败: ${err.message}`); } });
+        $("files-body").onclick=async(e)=>{ const n=e.target.closest("[data-fid]"); if(!n) return; state.fileId=n.dataset.fid; state.chunkOffset=0; renderTaskDetail(state.task); try{ await loadChunks(); }catch(err){ toast(`加载分块失败: ${err.message}`); } };
+        $("chunk-prev").onclick=async()=>{ if(state.chunkOffset<=0) return; state.chunkOffset=Math.max(0,state.chunkOffset-state.chunkLimit); try{ await loadChunks(); }catch(e){ toast(`翻页失败: ${e.message}`); } };
+        $("chunk-next").onclick=async()=>{ if(state.chunkOffset+state.chunkLimit>=state.chunkTotal) return; state.chunkOffset+=state.chunkLimit; try{ await loadChunks(); }catch(e){ toast(`翻页失败: ${e.message}`); } };
+      }
+
+      bind(); renderUploadFiles(); poll(); restartPoll();
+    </script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -679,6 +679,10 @@
         <div class="dock-icon">📂</div>
         <span>记忆溯源</span>
       </div>
+      <div class="dock-btn" onclick="openImportCenter()">
+        <div class="dock-icon">📥</div>
+        <span>导入中心</span>
+      </div>
       <div class="dock-btn" onclick="openPanel('person-profile-panel')">
         <div class="dock-icon">👤</div>
         <span>人物画像</span>
@@ -1663,7 +1667,9 @@
         isHighlighting = false; // Reset highlight state
         showLoader("正在同步图谱...", true);
         try {
-          let url = `/api/graph?exclude_leaf=${!detailedMode}&density=${infoDensity}`;
+          // 批次聚焦时强制展示完整子图，避免叶子过滤把导入关系全部裁掉。
+          const excludeLeaf = currentSource ? false : !detailedMode;
+          let url = `/api/graph?exclude_leaf=${excludeLeaf}&density=${infoDensity}`;
           if (currentSource) {
             url += `&source=${encodeURIComponent(currentSource)}`;
           }
@@ -1838,6 +1844,10 @@
 
       function layout() {
         if (network) network.stabilize();
+      }
+
+      function openImportCenter() {
+        window.open("/import", "_blank");
       }
 
       // --- Panel Control ---
@@ -2525,25 +2535,29 @@
           let header = "";
           if (currentSource) {
             header = `<div style="padding: 10px; background: rgba(56, 189, 248, 0.2); border-radius: 8px; margin-bottom: 15px; display: flex; justify-content: space-between; align-items: center;">
-                        <span>🔎 当前聚焦: <b>${currentSource}</b></span>
+                        <span>🔎 当前聚焦: <b>${escapeHtml(currentSource)}</b></span>
                         <button class="btn btn-ghost" style="padding: 4px 10px; font-size: 0.8rem;" onclick="setSourceFilter(null)">重置 / 查看全部</button>
                     </div>`;
           }
 
           const listHtml = sources
             .map(
-              (f) => `
+              (f) => {
+                const encodedSource = encodeURIComponent(f.source || "");
+                const safeSource = escapeHtml(f.source || "");
+                return `
                     <div class="list-item" style="display: flex; justify-content: space-between; align-items: center;">
                         <div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; margin-right: 15px;">
-                            <div style="font-size: 0.9rem; color: ${currentSource === f.source ? "var(--accent-primary)" : "white"};">${f.source}</div>
+                            <div style="font-size: 0.9rem; color: ${currentSource === f.source ? "var(--accent-primary)" : "white"};">${safeSource}</div>
                             <div style="font-size: 0.7rem; color: var(--text-dim);">${f.count} 段记忆记录</div>
                         </div>
                         <div style="display: flex; gap: 6px;">
-                            <button class="btn btn-ghost" style="padding: 4px 8px;" onclick="setSourceFilter('${f.source}')" title="聚焦此批次">👁️</button>
-                            <button class="btn btn-danger" style="padding: 4px 8px;" onclick="deleteSourceFile('${f.source}')" title="删除">🗑️</button>
+                            <button class="btn btn-ghost" style="padding: 4px 8px;" onclick="setSourceFilterByEncoded('${encodedSource}')" title="聚焦此批次">👁️</button>
+                            <button class="btn btn-danger" style="padding: 4px 8px;" onclick="deleteSourceFileByEncoded('${encodedSource}')" title="删除">🗑️</button>
                         </div>
                     </div>
-                `,
+                `;
+              },
             )
             .join("");
 
@@ -2559,6 +2573,17 @@
         loadSourceFiles(); // Refresh UI
         if (source) showToast(`已聚焦批次: ${source}`);
         else showToast("已重置视图");
+      }
+
+      function setSourceFilterByEncoded(encodedSource) {
+        const source = decodeURIComponent(encodedSource || "");
+        setSourceFilter(source || null);
+      }
+
+      function deleteSourceFileByEncoded(encodedSource) {
+        const source = decodeURIComponent(encodedSource || "");
+        if (!source) return;
+        deleteSourceFile(source);
       }
 
       async function deleteSourceFile(src) {


### PR DESCRIPTION
引入完整的 Web 导入中心及相关平台更新。新增 core/utils/web_import_manager.py（任务队列、状态管理、重试/取消、路径别名、manifest 处理），web/import.html，以及 scripts/migrate_maibot_memory.py；同时更新文档（README、QUICK_START、IMPORT_GUIDE、CONFIG_REFERENCE、CHANGELOG）及 Web UI。

版本号提升至 v0.6.0，并加入 web.import.* 配置项 schema，以及新增运行时依赖（networkx、pyarrow、pandas、python-multipart）。

此外：改进向量嵌入的重试与退避(backoff)策略（可配置倍率与异常处理），确保 debug server 正确初始化存储结构，并在执行删除操作时清理图数据库的 edge-hash 与 saliency 缓存。