### PR TITLE
docs:修正CLA中的A-Dawn账号类型

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -3,8 +3,8 @@
 Version 1.0, effective 2026-08-10
 
 This Contributor License Agreement (the "Agreement") applies to contributions
-submitted to the A_memorix open-source project maintained through the GitHub
-account A-Dawn (the "Project"), including the `A_memorix` and
+submitted to the A_memorix open-source project (the "Project"), which is
+maintained through the GitHub account A-Dawn and includes the `A_memorix` and
 `A_memorix-extensions` repositories.
 
 This is a license agreement, not a copyright assignment.

--- a/CLA.md
+++ b/CLA.md
@@ -4,7 +4,7 @@ Version 1.0, effective 2026-08-10
 
 This Contributor License Agreement (the "Agreement") applies to contributions
 submitted to the A_memorix open-source project maintained through the GitHub
-organization A-Dawn (the "Project"), including the `A_memorix` and
+account A-Dawn (the "Project"), including the `A_memorix` and
 `A_memorix-extensions` repositories.
 
 This is a license agreement, not a copyright assignment.


### PR DESCRIPTION
## 修改内容\n\n将 CLA 中对 A-Dawn 的描述由 GitHub Organization 修正为 GitHub account，使文本与当前账号类型一致。授权主体和授权范围没有变化。\n\n## 验证\n\n- git diff --check\n- 已通过 GitHub API 核对 A-Dawn 的账号类型