### PR TITLE
feat: 增加文件配置优先启动模式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 更新日志 (Changelog)
 
+## [2.0.0a4] - 2026-08-14
+
+本版本为 Agent 适配器增加文件配置优先模式。`a-memorix --no-environment-overrides --config <path> ...` 会忽略非密钥 `A_MEMORIX_*` 配置覆盖，使宿主生成的 TOML 成为唯一普通配置来源；Embedding、LLM、服务管理和客户端认证密钥仍可由独立环境变量注入，不会写入 TOML。未使用该开关时，原有命令行、环境变量、配置文件、默认值优先级保持不变。
+
 ## [2.0.0a3] - 2026-08-14
 
 本版本补齐面向 Agent 插件分发的标准记忆栈。新增生产级 OpenAI 兼容 Embedding、LLM Provider，支持环境变量或只读文件密钥、超时、并发、重试、响应校验和无密钥指纹。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A_memorix 是面向 AI Agent 的长期记忆服务。2.x 正在从 MaiBot 插件演进为独立 Python 包，通过彼此独立的 Namespace 和统一协议，为不同 Agent 提供可组合的写入、检索、图关系、时序证据和记忆维护能力。
 
-当前版本为 `2.0.0a3`。这一版本在通用核心、Namespace Runtime 和统一协议之上补齐了生产级 OpenAI 兼容 Provider、标准 MCP 启动门禁、Provider 与双向量池健康状态。Protobuf 是唯一网络 IDL，服务原生提供 gRPC，HTTP/JSON 由 gRPC-Gateway 根据同一份注解生成。每个 MCP 服务固定绑定一个 Namespace。现阶段适合参与核心开发、Adapter 验证和数据兼容性测试，不应视为稳定服务版本。
+当前版本为 `2.0.0a4`。这一版本在通用核心、Namespace Runtime 和统一协议之上补齐了生产级 OpenAI 兼容 Provider、标准 MCP 启动门禁、Provider 与双向量池健康状态，并允许宿主适配器明确禁止环境变量覆盖普通配置。Protobuf 是唯一网络 IDL，服务原生提供 gRPC，HTTP/JSON 由 gRPC-Gateway 根据同一份注解生成。每个 MCP 服务固定绑定一个 Namespace。现阶段适合参与核心开发、Adapter 验证和数据兼容性测试，不应视为稳定服务版本。
 
 ## 当前功能
 
@@ -173,7 +173,7 @@ a-memorix doctor --health-only
 
 远程地址、令牌文件和 TLS 参数放在命令组与子命令之间，例如 `a-memorix namespace --target memory.example:50051 --token-file ./admin-token list`。管理命令输出 JSON，错误输出到 stderr，并使用稳定错误码。
 
-配置采用 TOML，完整示例位于 [deploy/a-memorix.example.toml](deploy/a-memorix.example.toml)。优先级固定为命令行参数、环境变量、`--config` 或 `A_MEMORIX_CONFIG` 指定的文件、内置默认值。管理员令牌和 API Key 不写入 TOML，可通过 `A_MEMORIX_ADMIN_TOKEN`、`A_MEMORIX_API_KEY` 或只读令牌文件提供。执行 `a-memorix config` 可以查看不包含密钥值的生效配置。
+配置采用 TOML，完整示例位于 [deploy/a-memorix.example.toml](deploy/a-memorix.example.toml)。优先级固定为命令行参数、环境变量、`--config` 或 `A_MEMORIX_CONFIG` 指定的文件、内置默认值。宿主适配器需要让配置文件成为唯一普通配置来源时，可以同时传入 `--no-environment-overrides`；该开关不禁用独立的密钥环境变量。管理员令牌和 API Key 不写入 TOML，可通过 `A_MEMORIX_ADMIN_TOKEN`、`A_MEMORIX_API_KEY` 或只读令牌文件提供。执行 `a-memorix config` 可以查看不包含密钥值的生效配置。
 
 固定 Namespace MCP 默认使用 `standard` 模式。该模式要求安装 `a-memorix[mcp,vector]`，并配置 OpenAI 兼容的 Embedding、LLM 服务；启动时会验证 Faiss、实际向量维度、LLM、段落向量池和关系向量池。只有明确接受部分能力时才使用 `a-memorix mcp ... --mode degraded`。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a-memorix"
-version = "2.0.0a3"
+version = "2.0.0a4"
 description = "A namespace-isolated memory engine for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/a_memorix/__init__.py
+++ b/src/a_memorix/__init__.py
@@ -197,7 +197,7 @@ __all__ = [
     "load_adapter_manifest",
     "__version__",
 ]
-__version__ = "2.0.0a3"
+__version__ = "2.0.0a4"
 
 
 def __getattr__(name: str) -> Any:

--- a/src/a_memorix/cli.py
+++ b/src/a_memorix/cli.py
@@ -40,7 +40,10 @@ def main(argv: list[str] | None = None) -> int:
             result = _adapter_command(args)
             _print_value(result, pretty=args.pretty)
             return 0
-        config = load_config(args.config)
+        config = load_config(
+            args.config,
+            environ={} if args.no_environment_overrides else None,
+        )
         if args.command == "config":
             _print_value(config.redacted(), pretty=args.pretty)
             return 0
@@ -66,6 +69,14 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--config",
         help="explicit TOML configuration file; A_MEMORIX_CONFIG is the fallback",
+    )
+    parser.add_argument(
+        "--no-environment-overrides",
+        action="store_true",
+        help=(
+            "load non-secret settings only from --config and defaults; "
+            "provider and service credential environment variables remain available"
+        ),
     )
     parser.add_argument(
         "--pretty",

--- a/tests/test_cli_operations.py
+++ b/tests/test_cli_operations.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from pydantic import ValidationError
 
-from a_memorix.cli import _parser, _server_config
+from a_memorix.cli import _parser, _server_config, main
 from a_memorix.client import AMemorixClient
 from a_memorix.config import ObservabilityConfig, ServerTLSConfig, load_config
 from a_memorix.engine import AMemorixEngine
@@ -134,6 +134,44 @@ probe_llm = false
     )
     assert "embedding-secret" not in rendered
     assert "llm-secret" not in rendered
+
+
+def test_cli_can_disable_non_secret_environment_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "a-memorix.toml"
+    config_path.write_text(
+        """
+[providers.embedding]
+endpoint = "https://file.example/v1"
+model = "embedding-file"
+dimension = 768
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("A_MEMORIX_EMBEDDING_ENDPOINT", "https://env.example/v1")
+    monkeypatch.setenv("A_MEMORIX_EMBEDDING_MODEL", "embedding-env")
+    monkeypatch.setenv("A_MEMORIX_EMBEDDING_DIMENSION", "1024")
+    monkeypatch.setenv("A_MEMORIX_EMBEDDING_API_KEY", "embedding-secret")
+
+    result = main(
+        [
+            "--config",
+            str(config_path),
+            "--no-environment-overrides",
+            "config",
+        ]
+    )
+
+    assert result == 0
+    rendered = capsys.readouterr().out
+    payload = json.loads(rendered)
+    assert payload["providers"]["embedding"]["endpoint"] == "https://file.example/v1"
+    assert payload["providers"]["embedding"]["model"] == "embedding-file"
+    assert payload["providers"]["embedding"]["dimension"] == 768
+    assert "embedding-secret" not in rendered
 
 
 def test_mcp_parser_supports_explicit_degraded_mode() -> None:


### PR DESCRIPTION
## 变更内容

- 新增全局参数 `--no-environment-overrides`，使显式 TOML 与默认值成为普通配置的唯一来源
- 保留 Provider、服务管理与客户端认证密钥的独立环境注入能力
- 将版本更新为 `2.0.0a4`，同步 README 与更新日志

## 兼容性

未传入新参数时，现有命令行、环境变量、配置文件、默认值优先级保持不变。该能力供 DeepSeek Harness 等宿主适配器固定配置来源使用。

## 验证

- `python -m pytest -q`：736 passed，2 skipped
- `python -m mypy`
- `python -m build`
- `python -m twine check dist/*`
- `python -m ruff check src/a_memorix/cli.py tests/test_cli_operations.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--no-environment-overrides` option for file-first configuration.
  - Non-secret environment variables no longer override configuration file values when enabled.
  - Provider, service, embedding, and client-authentication secrets remain available through environment variables.
  - Existing configuration precedence remains unchanged unless the option is used.

- **Documentation**
  - Updated usage documentation and changelog with the new configuration mode.

- **Release**
  - Updated the application version to `2.0.0a4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->