### PR TITLE
fix: 正确标记预发布版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,12 @@ jobs:
         shell: bash
         run: sha256sum dist/* artifacts/* > SHA256SUMS
       - name: Create GitHub release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" dist/* artifacts/* SHA256SUMS --generate-notes --verify-tag --repo "${{ github.repository }}"
+        run: |
+          release_args=(--generate-notes --verify-tag --repo "${{ github.repository }}")
+          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${{ github.ref_name }}" dist/* artifacts/* SHA256SUMS "${release_args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,9 +174,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          release_args=(--generate-notes --verify-tag --repo "${{ github.repository }}")
-          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          release_args=(--generate-notes --verify-tag --repo "$RELEASE_REPOSITORY")
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             release_args+=(--prerelease)
           fi
-          gh release create "${{ github.ref_name }}" dist/* artifacts/* SHA256SUMS "${release_args[@]}"
+          gh release create "$RELEASE_TAG" dist/* artifacts/* SHA256SUMS "${release_args[@]}"


### PR DESCRIPTION
## 变更说明

- 稳定标签仅匹配 vX.Y.Z
- alpha、beta、rc 等非稳定标签自动创建为 GitHub 预发布版本
- 不改变 PyPI、容器镜像和二进制构建流程

## 验证

- git diff --check 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-release tags are now correctly marked as pre-releases when creating GitHub releases.
  * Standard semantic-version tags continue to create regular releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->