### PR TITLE
feat: enforce memory spaces and partitions inside retrieval kernel

### DIFF
--- a/core/retrieval/dual_path.py
+++ b/core/retrieval/dual_path.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import re
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Tuple, Union
 from enum import Enum
@@ -14,6 +15,7 @@ import numpy as np
 
 from src.common.logger import get_logger
 from ..storage import VectorStore, GraphStore, MetadataStore
+from ..runtime.models import MemoryAccessScope
 from ..embedding import EmbeddingAPIAdapter
 from ..utils.matcher import AhoCorasick
 from ..utils.time_parser import format_timestamp
@@ -265,6 +267,7 @@ class DualPathRetriever:
             re.IGNORECASE,
         )
         self._runtime_sparse_only = False
+        self._scope_context: ContextVar[Optional[MemoryAccessScope]] = ContextVar("a_memorix_scope", default=None)
 
     def set_runtime_sparse_only(self, enabled: bool) -> None:
         """由运行时控制强制 sparse-only（不改用户配置文件）。"""
@@ -280,6 +283,7 @@ class DualPathRetriever:
         top_k: Optional[int] = None,
         strategy: Optional[RetrievalStrategy] = None,
         temporal: Optional[TemporalQueryOptions] = None,
+        scope: Optional[MemoryAccessScope] = None,
     ) -> List[RetrievalResult]:
         """
         执行检索（异步方法）
@@ -295,6 +299,7 @@ class DualPathRetriever:
         """
         top_k = top_k or self.config.top_k_final
         strategy = strategy or self.config.retrieval_strategy
+        scope_token = self._scope_context.set(scope)
         relation_intent_ctx = self._build_relation_intent_context(query=query, top_k=top_k)
 
         logger.info(
@@ -305,7 +310,9 @@ class DualPathRetriever:
         )
 
         if temporal and not (query or "").strip():
-            return self._retrieve_temporal_only(temporal, top_k)
+            results = self._filter_scope_results(self._retrieve_temporal_only(temporal, top_k))
+            self._scope_context.reset(scope_token)
+            return results
 
         # 根据策略执行检索
         if strategy == RetrievalStrategy.PARA_ONLY:
@@ -320,6 +327,8 @@ class DualPathRetriever:
                 relation_intent=relation_intent_ctx,
             )
 
+        results = self._filter_scope_results(results)
+        self._scope_context.reset(scope_token)
         logger.info(f"检索完成: 返回 {len(results)} 条结果")
 
         # 调试模式：打印结果原文
@@ -329,6 +338,24 @@ class DualPathRetriever:
                 logger.info(f"  {i+1}. [{res.result_type}] (Score: {res.score:.4f}) {res.content}")
 
         return results
+
+    def _filter_scope_results(self, results: List[RetrievalResult]) -> List[RetrievalResult]:
+        scope = self._scope_context.get()
+        if scope is None:
+            return results
+        paragraph_ids = self.metadata_store.resolve_allowed_object_ids(scope, "paragraph")
+        relation_ids = self.metadata_store.resolve_allowed_object_ids(scope, "relation")
+        if paragraph_ids is None and relation_ids is None:
+            return results
+        allowed = (paragraph_ids or set()) | (relation_ids or set())
+        return [item for item in results if item.hash_value in allowed]
+
+    def _scope_allows(self, object_type: str, object_id: str) -> bool:
+        scope = self._scope_context.get()
+        if scope is None:
+            return True
+        allowed = self.metadata_store.resolve_allowed_object_ids(scope, object_type)
+        return allowed is None or object_id in allowed
 
     def _is_relation_intent_query(self, query: str) -> bool:
         q = str(query or "").strip()
@@ -596,6 +623,8 @@ class DualPathRetriever:
         results: List[RetrievalResult] = []
         for row in sparse_rows:
             hash_value = row["hash"]
+            if not self._scope_allows("paragraph", str(hash_value)):
+                continue
             paragraph = self.metadata_store.get_paragraph(hash_value)
             if paragraph is None:
                 continue
@@ -684,6 +713,8 @@ class DualPathRetriever:
         results: List[RetrievalResult] = []
         for row in rows:
             hash_value = row["hash"]
+            if not self._scope_allows("relation", str(hash_value)):
+                continue
             relation = self.metadata_store.get_relation(hash_value, include_inactive=False)
             if relation is None:
                 continue
@@ -845,6 +876,8 @@ class DualPathRetriever:
             )
 
             for hash_value, score in zip(para_ids, para_scores):
+                if not self._scope_allows("paragraph", str(hash_value)):
+                    continue
                 paragraph = self.metadata_store.get_paragraph(hash_value)
                 if paragraph is None:
                     continue
@@ -934,6 +967,8 @@ class DualPathRetriever:
 
             seen_relations = set()
             for hash_value, score in zip(ids, scores):
+                if not self._scope_allows("entity", str(hash_value)):
+                    continue
                 entity = self.metadata_store.get_entity(hash_value)
                 if not entity:
                     continue
@@ -1167,6 +1202,12 @@ class DualPathRetriever:
         elif sparse_rel_results and (not rel_results or not embedding_ok):
             rel_results = sparse_rel_results
 
+        para_results = self._filter_scope_results(para_results)
+        rel_results = self._filter_scope_results(rel_results)
+        sparse_para_results = self._filter_scope_results(sparse_para_results)
+        sparse_rel_results = self._filter_scope_results(sparse_rel_results)
+        graph_rel_results = self._filter_scope_results(graph_rel_results)
+
         # 融合结果
         fused_results = self._fuse_results(
             para_results,
@@ -1298,6 +1339,8 @@ class DualPathRetriever:
         seen_rel = set()
 
         for hash_value, score in zip(ids, scores):
+            if not self._scope_allows("paragraph", str(hash_value)) and not self._scope_allows("relation", str(hash_value)):
+                continue
             paragraph = self.metadata_store.get_paragraph(hash_value)
             if paragraph is not None and hash_value not in seen_para:
                 seen_para.add(hash_value)
@@ -1388,6 +1431,8 @@ class DualPathRetriever:
 
         results = []
         for hash_value, score in zip(para_ids, para_scores):
+            if not self._scope_allows("paragraph", str(hash_value)):
+                continue
             paragraph = self.metadata_store.get_paragraph(hash_value)
             if paragraph is None:
                 continue
@@ -1432,6 +1477,8 @@ class DualPathRetriever:
 
         results = []
         for hash_value, score in zip(rel_ids, rel_scores):
+            if not self._scope_allows("relation", str(hash_value)):
+                continue
             relation = self.metadata_store.get_relation(hash_value, include_inactive=False)
             if relation is None:
                 continue

--- a/core/runtime/models.py
+++ b/core/runtime/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+_ALLOWED_SECURITY_DOMAINS = {"normal", "kami"}
+
+
+@dataclass(frozen=True)
+class MemoryAccessScope:
+    """Trusted retrieval/write scope for logical memory isolation.
+
+    ``force_all_memory_access`` is intentionally not part of user-facing payloads;
+    hosts must only construct it after authenticating a trusted Kami session.
+    """
+
+    allowed_memory_space_ids: tuple[str, ...] = ()
+    allowed_partition_ids: tuple[str, ...] = ()
+    security_domain: str = "normal"
+    force_all_memory_access: bool = False
+    access_trace_id: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_memory_space_ids", _clean(self.allowed_memory_space_ids))
+        object.__setattr__(self, "allowed_partition_ids", _clean(self.allowed_partition_ids))
+        domain = str(self.security_domain or "normal").strip().lower()
+        if domain not in _ALLOWED_SECURITY_DOMAINS:
+            raise ValueError(f"unsupported security_domain: {domain}")
+        if domain == "normal" and self.force_all_memory_access:
+            raise ValueError("force_all_memory_access requires security_domain='kami'")
+        if domain == "normal" and any(item == "*" for item in self.allowed_memory_space_ids + self.allowed_partition_ids):
+            raise ValueError("normal scope cannot use wildcard access")
+        object.__setattr__(self, "security_domain", domain)
+        object.__setattr__(self, "force_all_memory_access", bool(self.force_all_memory_access))
+        object.__setattr__(self, "access_trace_id", str(self.access_trace_id or "").strip())
+
+    @classmethod
+    def normal(cls) -> "MemoryAccessScope":
+        return cls()
+
+    @classmethod
+    def trusted_kami(cls, *, access_trace_id: str = "") -> "MemoryAccessScope":
+        return cls(security_domain="kami", force_all_memory_access=True, access_trace_id=access_trace_id)
+
+    def allows(self, *, memory_space_id: str, partition_id: str, security_domain: str = "normal") -> bool:
+        if self.force_all_memory_access and self.security_domain == "kami":
+            return str(security_domain or "normal").lower() == "kami"
+        if str(security_domain or "normal").lower() != self.security_domain:
+            return False
+        spaces = set(self.allowed_memory_space_ids)
+        partitions = set(self.allowed_partition_ids)
+        return (not spaces or memory_space_id in spaces) and (not partitions or partition_id in partitions)
+
+
+def _clean(values: Optional[Iterable[str]]) -> tuple[str, ...]:
+    if not values:
+        return ()
+    return tuple(dict.fromkeys(str(value or "").strip() for value in values if str(value or "").strip()))

--- a/core/runtime/sdk_memory_kernel.py
+++ b/core/runtime/sdk_memory_kernel.py
@@ -34,6 +34,7 @@ from ..utils.summary_importer import SummaryImporter
 from ..utils.time_parser import format_timestamp, parse_query_datetime_to_timestamp
 from ..utils.web_import_manager import ImportTaskManager
 from .search_runtime_initializer import SearchRuntimeBundle, build_search_runtime
+from .models import MemoryAccessScope
 
 logger = get_logger("A_Memorix.SDKMemoryKernel")
 
@@ -50,6 +51,11 @@ class KernelSearchRequest:
     respect_filter: bool = True
     user_id: str = ""
     group_id: str = ""
+    allowed_memory_space_ids: tuple[str, ...] = ()
+    allowed_partition_ids: tuple[str, ...] = ()
+    security_domain: str = "normal"
+    force_all_memory_access: bool = False
+    access_trace_id: str = ""
 
 
 @dataclass
@@ -923,6 +929,11 @@ class SDKMemoryKernel:
         respect_filter: bool = True,
         user_id: str = "",
         group_id: str = "",
+        memory_space_id: str = "memory-space-public",
+        partition_id: str = "shared",
+        security_domain: str = "normal",
+        source_session_id: str = "",
+        bot_profile_id: str = "",
     ) -> Dict[str, Any]:
         content = normalize_text(text)
         external_token = str(external_id or "").strip() or compute_hash(f"{source_type}:{chat_id}:{content}")
@@ -981,6 +992,11 @@ class SDKMemoryKernel:
             knowledge_type=self._resolve_knowledge_type(source_type),
             time_meta=self._time_meta(timestamp, time_start, time_end),
         )
+        self.metadata_store.register_scope_member(
+            object_type="paragraph", object_id=paragraph_hash,
+            memory_space_id=memory_space_id, partition_id=partition_id,
+            security_domain=security_domain, source_session_id=source_session_id or None,
+        )
         vector_result = await self._write_paragraph_vector_or_enqueue(
             paragraph_hash=paragraph_hash,
             content=content,
@@ -991,7 +1007,12 @@ class SDKMemoryKernel:
             warnings.append(warning)
 
         for name in entity_tokens:
-            self.metadata_store.add_entity(name=name, source_paragraph=paragraph_hash)
+            entity_hash = self.metadata_store.add_entity(name=name, source_paragraph=paragraph_hash)
+            self.metadata_store.register_scope_member(
+                object_type="entity", object_id=entity_hash,
+                memory_space_id=memory_space_id, partition_id=partition_id,
+                security_domain=security_domain, source_session_id=source_session_id or None,
+            )
 
         stored_relations: List[str] = []
         for row in [dict(item) for item in (relations or []) if isinstance(item, dict)]:
@@ -1010,6 +1031,11 @@ class SDKMemoryKernel:
                 write_vector=self.relation_vectors_enabled,
             )
             self.metadata_store.link_paragraph_relation(paragraph_hash, result.hash_value)
+            self.metadata_store.register_scope_member(
+                object_type="relation", object_id=result.hash_value,
+                memory_space_id=memory_space_id, partition_id=partition_id,
+                security_domain=security_domain, source_session_id=source_session_id or None,
+            )
             stored_relations.append(result.hash_value)
 
         self.metadata_store.upsert_external_memory_ref(
@@ -1128,6 +1154,11 @@ class SDKMemoryKernel:
         except ValueError as exc:
             return {"summary": "", "hits": [], "error": str(exc)}
 
+        scope = MemoryAccessScope(
+            allowed_memory_space_ids=request.allowed_memory_space_ids,
+            allowed_partition_ids=request.allowed_partition_ids, security_domain=request.security_domain,
+            force_all_memory_access=request.force_all_memory_access, access_trace_id=request.access_trace_id,
+        )
         if mode == "episode":
             rows = await self.episode_retriever.query(
                 query=query,
@@ -1179,6 +1210,7 @@ class SDKMemoryKernel:
                 source=self._chat_source(request.chat_id),
                 use_threshold=True,
                 enable_ppr=bool(self._cfg("retrieval.enable_ppr", True)),
+                memory_scope=scope,
             ),
             enforce_chat_filter=bool(request.respect_filter),
             reinforce_access=True,

--- a/core/storage/metadata_store.py
+++ b/core/storage/metadata_store.py
@@ -34,7 +34,7 @@ except Exception:
 logger = get_logger("A_Memorix.MetadataStore")
 
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 RUNTIME_AUTO_MIGRATION_MIN_SCHEMA_VERSION = 9
 
 
@@ -321,6 +321,23 @@ class MetadataStore:
             )
         """)
 
+        cursor.execute("""CREATE TABLE IF NOT EXISTS memory_scope_members (
+                object_type TEXT NOT NULL, object_id TEXT NOT NULL,
+                memory_space_id TEXT NOT NULL, partition_id TEXT NOT NULL,
+                security_domain TEXT NOT NULL DEFAULT 'normal',
+                source_session_id TEXT, created_at REAL NOT NULL,
+                PRIMARY KEY (object_type, object_id, partition_id)
+            )""")
+        cursor.execute("""CREATE INDEX IF NOT EXISTS idx_memory_scope_members_scope
+            ON memory_scope_members(security_domain, memory_space_id, partition_id, object_type)""")
+        cursor.execute("""CREATE TABLE IF NOT EXISTS relation_scope_states (
+                partition_id TEXT NOT NULL, relation_hash TEXT NOT NULL,
+                confidence REAL DEFAULT 1.0, is_inactive INTEGER DEFAULT 0,
+                retention_strength REAL DEFAULT 1.0, access_count INTEGER DEFAULT 0,
+                last_reinforced_at REAL, PRIMARY KEY (partition_id, relation_hash)
+            )""")
+        cursor.execute("""CREATE INDEX IF NOT EXISTS idx_relation_scope_states_hash
+            ON relation_scope_states(relation_hash, partition_id)""")
         # 三元组与段落的关联表
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS paragraph_relations (
@@ -756,6 +773,31 @@ class MetadataStore:
             )
         """)
 
+        cursor.execute("""CREATE TABLE IF NOT EXISTS memory_scope_members (
+                object_type TEXT NOT NULL, object_id TEXT NOT NULL,
+                memory_space_id TEXT NOT NULL, partition_id TEXT NOT NULL,
+                security_domain TEXT NOT NULL DEFAULT 'normal', source_session_id TEXT,
+                created_at REAL NOT NULL, PRIMARY KEY (object_type, object_id, partition_id)
+            )""")
+        cursor.execute("""CREATE INDEX IF NOT EXISTS idx_memory_scope_members_scope
+            ON memory_scope_members(security_domain, memory_space_id, partition_id, object_type)""")
+        cursor.execute("""CREATE TABLE IF NOT EXISTS relation_scope_states (
+                partition_id TEXT NOT NULL, relation_hash TEXT NOT NULL,
+                confidence REAL DEFAULT 1.0, is_inactive INTEGER DEFAULT 0,
+                retention_strength REAL DEFAULT 1.0, access_count INTEGER DEFAULT 0,
+                last_reinforced_at REAL, PRIMARY KEY (partition_id, relation_hash)
+            )""")
+        cursor.execute("""CREATE INDEX IF NOT EXISTS idx_relation_scope_states_hash
+            ON relation_scope_states(relation_hash, partition_id)""")
+        cursor.execute("""INSERT OR IGNORE INTO memory_scope_members
+            (object_type, object_id, memory_space_id, partition_id, security_domain, created_at)
+            SELECT 'paragraph', hash, 'memory-space-public',
+            CASE WHEN source IS NULL OR source = '' THEN 'shared' ELSE 'conversation' END,
+            'normal', COALESCE(created_at, ?) FROM paragraphs""", (datetime.now().timestamp(),))
+        cursor.execute("""INSERT OR IGNORE INTO memory_scope_members
+            (object_type, object_id, memory_space_id, partition_id, security_domain, created_at)
+            SELECT 'relation', hash, 'memory-space-public', 'shared', 'normal',
+            COALESCE(created_at, ?) FROM relations""", (datetime.now().timestamp(),))
         # Episode MVP 表结构补齐
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS episodes (
@@ -1326,6 +1368,67 @@ class MetadataStore:
         if resolved is None:
             raise RuntimeError("MetadataStore 未连接数据库")
         return resolved
+
+    def register_scope_member(self, *, object_type: str, object_id: str,
+                              memory_space_id: str = "memory-space-public",
+                              partition_id: str = "shared", security_domain: str = "normal",
+                              source_session_id: Optional[str] = None) -> None:
+        """幂等登记对象的逻辑记忆作用域。"""
+        object_type = str(object_type or "").strip().lower()
+        object_id = str(object_id or "").strip()
+        memory_space_id = str(memory_space_id or "memory-space-public").strip()
+        partition_id = str(partition_id or "shared").strip()
+        security_domain = str(security_domain or "normal").strip().lower()
+        if not object_type or not object_id or security_domain not in {"normal", "kami"}:
+            raise ValueError("invalid memory scope member")
+        now = datetime.now().timestamp()
+        self._conn.execute("""INSERT OR IGNORE INTO memory_scope_members
+            (object_type, object_id, memory_space_id, partition_id, security_domain,
+             source_session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (object_type, object_id, memory_space_id, partition_id, security_domain,
+             source_session_id, now))
+        if object_type == "relation":
+            self._conn.execute("""INSERT OR IGNORE INTO relation_scope_states
+                (partition_id, relation_hash, confidence, last_reinforced_at)
+                VALUES (?, ?, 1.0, ?)""", (partition_id, object_id, now))
+        self._conn.commit()
+
+    def resolve_allowed_object_ids(self, scope: Any, object_type: str) -> Optional[set[str]]:
+        """返回允许对象 ID；可信 Kami 全量访问返回 None。"""
+        if scope is None:
+            return None
+        if bool(getattr(scope, "force_all_memory_access", False)) and getattr(scope, "security_domain", "normal") == "kami":
+            return None
+        domain = str(getattr(scope, "security_domain", "normal") or "normal")
+        clauses = ["object_type = ?", "security_domain = ?"]
+        params: list[Any] = [object_type, domain]
+        spaces = tuple(getattr(scope, "allowed_memory_space_ids", ()) or ())
+        partitions = tuple(getattr(scope, "allowed_partition_ids", ()) or ())
+        if spaces:
+            clauses.append("memory_space_id IN (" + ",".join("?" for _ in spaces) + ")")
+            params.extend(spaces)
+        if partitions:
+            clauses.append("partition_id IN (" + ",".join("?" for _ in partitions) + ")")
+            params.extend(partitions)
+        rows = self._conn.execute("SELECT object_id FROM memory_scope_members WHERE " +
+                                  " AND ".join(clauses), params).fetchall()
+        return {str(row[0]) for row in rows}
+
+    def ensure_legacy_scope_backfill(self) -> int:
+        """幂等回填旧数据到公共 normal 空间。"""
+        before = self._conn.total_changes
+        now = datetime.now().timestamp()
+        self._conn.execute("""INSERT OR IGNORE INTO memory_scope_members
+            (object_type, object_id, memory_space_id, partition_id, security_domain, created_at)
+            SELECT 'paragraph', hash, 'memory-space-public',
+            CASE WHEN source IS NULL OR source = '' THEN 'shared' ELSE 'conversation' END,
+            'normal', COALESCE(created_at, ?) FROM paragraphs""", (now,))
+        self._conn.execute("""INSERT OR IGNORE INTO memory_scope_members
+            (object_type, object_id, memory_space_id, partition_id, security_domain, created_at)
+            SELECT 'relation', hash, 'memory-space-public', 'shared', 'normal',
+            COALESCE(created_at, ?) FROM relations""", (now,))
+        self._conn.commit()
+        return self._conn.total_changes - before
 
     def get_db_path(self) -> Path:
         """获取 SQLite 数据库文件路径。"""

--- a/core/utils/search_execution_service.py
+++ b/core/utils/search_execution_service.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from src.common.logger import get_logger
 
 from ..retrieval import TemporalQueryOptions
+from ..runtime.models import MemoryAccessScope
 from .search_postprocess import (
     apply_safe_content_dedup,
     maybe_apply_smart_path_fallback,
@@ -57,6 +58,7 @@ class SearchExecutionRequest:
     source: Optional[str] = None
     use_threshold: bool = True
     enable_ppr: bool = True
+    memory_scope: Optional[MemoryAccessScope] = None
 
 
 @dataclass
@@ -198,6 +200,7 @@ class SearchExecutionService:
             "top_k": int(top_k),
             "use_threshold": bool(request.use_threshold),
             "enable_ppr": bool(request.enable_ppr),
+            "memory_scope": repr(request.memory_scope),
         }
         payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
         return hashlib.sha1(payload_json.encode("utf-8")).hexdigest()
@@ -294,6 +297,7 @@ class SearchExecutionService:
                     query=query,
                     top_k=top_k,
                     temporal=temporal,
+                    scope=request.memory_scope,
                 )
 
                 should_apply_threshold = bool(request.use_threshold) and threshold_filter is not None

--- a/host_service.py
+++ b/host_service.py
@@ -196,6 +196,11 @@ class AMemorixHostService:
                     respect_filter=bool(payload.get("respect_filter", True)),
                     user_id=str(payload.get("user_id", "") or "").strip(),
                     group_id=str(payload.get("group_id", "") or "").strip(),
+                    allowed_memory_space_ids=tuple(str(x) for x in (payload.get("allowed_memory_space_ids") or [])),
+                    allowed_partition_ids=tuple(str(x) for x in (payload.get("allowed_partition_ids") or [])),
+                    security_domain=str(payload.get("security_domain", "normal") or "normal"),
+                    access_trace_id=str(payload.get("access_trace_id", "") or ""),
+                    # force_all_memory_access is host-trusted only and never read from payload.
                 )
             )
 
@@ -244,6 +249,11 @@ class AMemorixHostService:
                 respect_filter=bool(payload.get("respect_filter", True)),
                 user_id=str(payload.get("user_id", "") or "").strip(),
                 group_id=str(payload.get("group_id", "") or "").strip(),
+                memory_space_id=str(payload.get("memory_space_id", "memory-space-public") or "memory-space-public"),
+                partition_id=str(payload.get("partition_id", "shared") or "shared"),
+                security_domain=str(payload.get("security_domain", "normal") or "normal"),
+                source_session_id=str(payload.get("source_session_id", "") or ""),
+                bot_profile_id=str(payload.get("bot_profile_id", "") or ""),
             )
 
         if component_name == "get_person_profile":


### PR DESCRIPTION
## Summary

Enforce memory-space, partition, and security-domain scope inside the A-Memorix retrieval kernel before candidates enter ranking or summarization.

## Key changes

- Adds trusted kernel search scope fields for allowed memory spaces, partitions, security domain, force-all access, and trace id.
- Applies scope before dense/sparse/graph candidate processing.
- Adds metadata membership lookups and defensive authorization checks.
- Keeps host integration capable of passing trusted scope without exposing force-all access as a model/plugin parameter.

## Integration trace

- Upstream base: `e54bf256dd984d174eaf5fc7b6a420db8b6a78a8`
- Implementation commit: `7e1ee0335d6032bb92066454465fd197e95909ca`
- MaiBot integration commit: `6f9baf9e1f7f704d2281553fe0cc6a27f91c1083`
- MaiBot implementation branch: `YANGFENG0001/MaiBot:feature/workspace-bot-permission-kami`

## Validation

The corresponding MaiBot memory/workspace integration suite was rerun successfully (20 relevant tests passed), with Ruff and diff checks passing. The MaiBot subtree will be formally re-synced from `A-Dawn/A_memorix:MaiBot_branch` after this PR is merged, followed by the full Phase 4A regression suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scoped memory access controls for searches and text ingestion.
  - Search and ingestion can now use memory spaces, partitions, security domains, and access trace identifiers.
  - Added trusted full-access support for authorized operations.
  - Scoped filtering now applies consistently across paragraph, relation, entity, temporal, keyword, and vector retrieval.

- **Bug Fixes**
  - Prevented retrieval results from exposing content outside the permitted memory scope.
  - Preserved access to existing data through automatic legacy scope migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->